### PR TITLE
feat: expose flange ref

### DIFF
--- a/src/components/robots/ABB_1200_07_7.tsx
+++ b/src/components/robots/ABB_1200_07_7.tsx
@@ -21,21 +21,17 @@ export function ABB_1200_07_7({
         <group name="visuals">
           <mesh
             name="visuals_1"
-            castShadow
-            receiveShadow
             geometry={nodes.visuals_1.geometry}
             material={materials.abb_metal_polished}
           />
           <mesh
             name="visuals_2"
-            castShadow
-            receiveShadow
             geometry={nodes.visuals_2.geometry}
             material={materials.abb_white}
           />
         </group>
         <animated.group name="ABB_IRB1200_J00">
-          <animated.group
+          <group
             name="ABB_IRB1200_J01"
             position={[0, 0.399, 0]}
             rotation={[-Math.PI / 2, -Math.PI / 2, 0]}
@@ -62,8 +58,6 @@ export function ABB_1200_07_7({
                     />
                     <mesh
                       name="visuals006"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals006.geometry}
                       material={materials.abb_metal_black}
                       position={[0.791, -0.351, 0]}
@@ -77,15 +71,11 @@ export function ABB_1200_07_7({
                   >
                     <mesh
                       name="visuals005_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals005_1.geometry}
                       material={materials.abb_metal_polished}
                     />
                     <mesh
                       name="visuals005_2"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals005_2.geometry}
                       material={materials.abb_white}
                     />
@@ -98,22 +88,16 @@ export function ABB_1200_07_7({
                 >
                   <mesh
                     name="visuals004_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals004_1.geometry}
                     material={materials.abb_metal_polished}
                   />
                   <mesh
                     name="visuals004_2"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals004_2.geometry}
                     material={materials.abb_white}
                   />
                   <mesh
                     name="visuals004_3"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals004_3.geometry}
                     material={materials.abb_red}
                   />
@@ -126,22 +110,16 @@ export function ABB_1200_07_7({
               >
                 <mesh
                   name="visuals003_1"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals003_1.geometry}
                   material={materials.abb_white}
                 />
                 <mesh
                   name="visuals003_2"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals003_2.geometry}
                   material={materials.abb_red}
                 />
                 <mesh
                   name="visuals003_3"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals003_3.geometry}
                   material={materials.abb_metal_polished}
                 />
@@ -154,32 +132,24 @@ export function ABB_1200_07_7({
             >
               <mesh
                 name="visuals002_1"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals002_1.geometry}
                 material={materials.abb_white}
               />
               <mesh
                 name="visuals002_2"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals002_2.geometry}
                 material={materials.abb_metal_polished}
               />
             </group>
-          </animated.group>
+          </group>
           <group name="visuals001">
             <mesh
               name="visuals001_1"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals001_1.geometry}
               material={materials.abb_white}
             />
             <mesh
               name="visuals001_2"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals001_2.geometry}
               material={materials.abb_metal_polished}
             />

--- a/src/components/robots/ABB_1200_07_7.tsx
+++ b/src/components/robots/ABB_1200_07_7.tsx
@@ -6,7 +6,11 @@ ABB_1200_07_7.config = {
   rotationOffsets: [0, -Math.PI / 2, 0, 0, 0, 0],
 }
 
-export function ABB_1200_07_7({ modelURL, ...props }: RobotModelProps) {
+export function ABB_1200_07_7({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
   const nodes = gltf.nodes
   const materials = gltf.materials
@@ -51,7 +55,11 @@ export function ABB_1200_07_7({ modelURL, ...props }: RobotModelProps) {
                     name="ABB_IRB1200_J05"
                     rotation={[Math.PI / 2, 0, -Math.PI]}
                   >
-                    <group name="ABB_IRB1200_FLG" position={[0, 0.082, 0]} />
+                    <group
+                      ref={flangeRef}
+                      name="ABB_IRB1200_FLG"
+                      position={[0, 0.082, 0]}
+                    />
                     <mesh
                       name="visuals006"
                       castShadow

--- a/src/components/robots/ABB_1300_115_10.tsx
+++ b/src/components/robots/ABB_1300_115_10.tsx
@@ -6,7 +6,11 @@ ABB_1300_115_10.config = {
   rotationOffsets: [0, -Math.PI / 2, 0, 0, 0, 0],
 }
 
-export function ABB_1300_115_10({ modelURL, ...props }: RobotModelProps) {
+export function ABB_1300_115_10({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
   const nodes = gltf.nodes
   const materials = gltf.materials
@@ -46,6 +50,7 @@ export function ABB_1300_115_10({ modelURL, ...props }: RobotModelProps) {
                     rotation={[Math.PI / 2, 0, -Math.PI]}
                   >
                     <group
+                      ref={flangeRef}
                       name="ABB_IRB_1300_115_10_FLG"
                       position={[0, 0.092, 0]}
                     />

--- a/src/components/robots/ABB_1300_115_10.tsx
+++ b/src/components/robots/ABB_1300_115_10.tsx
@@ -18,61 +18,81 @@ export function ABB_1300_115_10({
   return (
     <group {...props} dispose={null}>
       <group name="Scene">
-        <mesh
-          name="link_0"
-          castShadow
-          receiveShadow
-          geometry={nodes.link_0.geometry}
-          material={materials.Plastic}
-        />
-        <animated.group name="ABB_IRB_1300_115_10_J00">
+        <group name="link_0">
+          <mesh
+            name="visuals_0"
+            geometry={nodes.visuals_0.geometry}
+            material={materials.abb_metal_black}
+          />
+          <mesh
+            name="visuals_0_1"
+            geometry={nodes.visuals_0_1.geometry}
+            material={materials.abb_white}
+          />
+          <mesh
+            name="visuals_0_2"
+            geometry={nodes.visuals_0_2.geometry}
+            material={materials.abb_metal_polished}
+          />
+          <mesh
+            name="visuals_0_3"
+            geometry={nodes.visuals_0_3.geometry}
+            material={materials.abb_red}
+          />
+        </group>
+        <animated.group name="ABB_IRB1300_115_10_J00">
           <animated.group
-            name="ABB_IRB_1300_115_10_J01"
+            name="ABB_IRB1300_115_10_J01"
             position={[0.15, 0.544, 0]}
             rotation={[-Math.PI / 2, -Math.PI / 2, 0]}
           >
             <animated.group
-              name="ABB_IRB_1300_115_10_J02"
+              name="ABB_IRB1300_115_10_J02"
               position={[0.575, 0, 0]}
             >
               <animated.group
-                name="ABB_IRB_1300_115_10_J03"
+                name="ABB_IRB1300_115_10_J03"
                 position={[0.04, 0, 0]}
                 rotation={[-Math.PI / 2, 0, 0]}
               >
                 <animated.group
-                  name="ABB_IRB_1300_115_10_J04"
+                  name="ABB_IRB1300_115_10_J04"
                   position={[0, 0.425, 0]}
                   rotation={[Math.PI / 2, 0, 0]}
                 >
                   <animated.group
-                    name="ABB_IRB_1300_115_10_J05"
+                    name="ABB_IRB1300_115_10_J05"
                     rotation={[Math.PI / 2, 0, -Math.PI]}
                   >
                     <group
                       ref={flangeRef}
-                      name="ABB_IRB_1300_115_10_FLG"
+                      name="ABB_IRB1300_115_10_FLG"
                       position={[0, 0.092, 0]}
                     />
                     <mesh
                       name="link_6"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.link_6.geometry}
-                      material={materials.Metal}
+                      material={materials.abb_metal_polished}
                       position={[1.159, -0.575, 0]}
                       rotation={[0, 0, Math.PI / 2]}
                     />
                   </animated.group>
-                  <mesh
+                  <group
                     name="link_5"
-                    castShadow
-                    receiveShadow
-                    geometry={nodes.link_5.geometry}
-                    material={materials.Plastic}
                     position={[-1.159, 0, 0.575]}
                     rotation={[Math.PI / 2, 0, -Math.PI / 2]}
-                  />
+                  >
+                    <mesh
+                      name="visuals_5"
+                      geometry={nodes.visuals_5.geometry}
+                      material={materials.abb_white}
+                    />
+                    <mesh
+                      name="visuals_5_1"
+                      geometry={nodes.visuals_5_1.geometry}
+                      material={materials.abb_metal_black}
+                    />
+                  </group>
                 </animated.group>
                 <group
                   name="link_4"
@@ -80,18 +100,24 @@ export function ABB_1300_115_10({
                   rotation={[-Math.PI, 0, -Math.PI / 2]}
                 >
                   <mesh
-                    name="visuals004"
-                    castShadow
-                    receiveShadow
-                    geometry={nodes.visuals004.geometry}
-                    material={materials.Plastic}
+                    name="visuals_4"
+                    geometry={nodes.visuals_4.geometry}
+                    material={materials.abb_metal_polished}
                   />
                   <mesh
-                    name="visuals004_1"
-                    castShadow
-                    receiveShadow
-                    geometry={nodes.visuals004_1.geometry}
-                    material={materials.PlasticRed}
+                    name="visuals_4_1"
+                    geometry={nodes.visuals_4_1.geometry}
+                    material={materials.abb_white}
+                  />
+                  <mesh
+                    name="visuals_4_2"
+                    geometry={nodes.visuals_4_2.geometry}
+                    material={materials.abb_red}
+                  />
+                  <mesh
+                    name="visuals_4_3"
+                    geometry={nodes.visuals_4_3.geometry}
+                    material={materials.abb_metal_black}
                   />
                 </group>
               </animated.group>
@@ -101,45 +127,51 @@ export function ABB_1300_115_10({
                 rotation={[Math.PI / 2, 0, -Math.PI / 2]}
               >
                 <mesh
-                  name="visuals003"
-                  castShadow
-                  receiveShadow
-                  geometry={nodes.visuals003.geometry}
-                  material={materials.Plastic}
+                  name="visuals_3"
+                  geometry={nodes.visuals_3.geometry}
+                  material={materials.abb_white}
                 />
                 <mesh
-                  name="visuals003_1"
-                  castShadow
-                  receiveShadow
-                  geometry={nodes.visuals003_1.geometry}
-                  material={materials.PlasticRed}
+                  name="visuals_3_1"
+                  geometry={nodes.visuals_3_1.geometry}
+                  material={materials.abb_red}
                 />
                 <mesh
-                  name="visuals003_2"
-                  castShadow
-                  receiveShadow
-                  geometry={nodes.visuals003_2.geometry}
-                  material={materials.Plastic}
+                  name="visuals_3_2"
+                  geometry={nodes.visuals_3_2.geometry}
+                  material={materials.abb_metal_black}
                 />
               </group>
             </animated.group>
-            <mesh
+            <group
               name="link_2"
-              castShadow
-              receiveShadow
-              geometry={nodes.link_2.geometry}
-              material={materials.Plastic}
               position={[-0.544, 0, 0.15]}
               rotation={[Math.PI / 2, 0, -Math.PI / 2]}
-            />
+            >
+              <mesh
+                name="visuals_2"
+                geometry={nodes.visuals_2.geometry}
+                material={materials.abb_white}
+              />
+              <mesh
+                name="visuals_2_1"
+                geometry={nodes.visuals_2_1.geometry}
+                material={materials.abb_metal_black}
+              />
+            </group>
           </animated.group>
-          <mesh
-            name="link_1"
-            castShadow
-            receiveShadow
-            geometry={nodes.link_1.geometry}
-            material={materials.Plastic}
-          />
+          <group name="link_1">
+            <mesh
+              name="visuals_1"
+              geometry={nodes.visuals_1.geometry}
+              material={materials.abb_white}
+            />
+            <mesh
+              name="visuals_1_1"
+              geometry={nodes.visuals_1_1.geometry}
+              material={materials.abb_metal_black}
+            />
+          </group>
         </animated.group>
       </group>
     </group>

--- a/src/components/robots/FANUC_ARC_Mate_100iD.tsx
+++ b/src/components/robots/FANUC_ARC_Mate_100iD.tsx
@@ -6,7 +6,11 @@ FANUC_ARC_Mate_100iD.config = {
   rotationOffsets: [0, Math.PI / 2, 0, 0, 0, 0],
 }
 
-export function FANUC_ARC_Mate_100iD({ modelURL, ...props }: RobotModelProps) {
+export function FANUC_ARC_Mate_100iD({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
   const nodes = gltf.nodes
   const materials = gltf.materials
@@ -38,6 +42,7 @@ export function FANUC_ARC_Mate_100iD({ modelURL, ...props }: RobotModelProps) {
                         rotation={[-Math.PI / 2, 0, 0]}
                       >
                         <group
+                          ref={flangeRef}
                           name="M10iD_FLG"
                           position={[0, -0.075, 0]}
                           rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/FANUC_ARC_Mate_100iD.tsx
+++ b/src/components/robots/FANUC_ARC_Mate_100iD.tsx
@@ -49,8 +49,6 @@ export function FANUC_ARC_Mate_100iD({
                         />
                         <mesh
                           name="M10iD_L06"
-                          castShadow
-                          receiveShadow
                           geometry={nodes.M10iD_L06.geometry}
                           material={materials.Fanuc_BlackMetal_AO}
                           position={[-0.835, 0.775, 0]}
@@ -59,8 +57,6 @@ export function FANUC_ARC_Mate_100iD({
                       </animated.group>
                       <mesh
                         name="M10iD_L05"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.M10iD_L05.geometry}
                         material={materials.Fanuc_BlackMetal_AO}
                         position={[-0.835, 0, -0.775]}
@@ -74,15 +70,11 @@ export function FANUC_ARC_Mate_100iD({
                     >
                       <mesh
                         name="Mesh_654"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.Mesh_654.geometry}
                         material={materials.Fanuc_Yellow_Textured_AO}
                       />
                       <mesh
                         name="Mesh_654_1"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.Mesh_654_1.geometry}
                         material={materials.Fanuc_BlackMetal_AO}
                       />
@@ -95,22 +87,16 @@ export function FANUC_ARC_Mate_100iD({
                   >
                     <mesh
                       name="Mesh_378"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.Mesh_378.geometry}
                       material={materials.Material_1_AO}
                     />
                     <mesh
                       name="Mesh_378_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.Mesh_378_1.geometry}
                       material={materials.Fanuc_Yellow_Textured_AO}
                     />
                     <mesh
                       name="Mesh_378_2"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.Mesh_378_2.geometry}
                       material={materials.Fanuc_BlackMetal_AO}
                     />
@@ -123,15 +109,11 @@ export function FANUC_ARC_Mate_100iD({
                 >
                   <mesh
                     name="Mesh_358"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.Mesh_358.geometry}
                     material={materials.Fanuc_Yellow_Textured_AO}
                   />
                   <mesh
                     name="Mesh_358_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.Mesh_358_1.geometry}
                     material={materials.Fanuc_BlackMetal_AO}
                   />
@@ -140,22 +122,16 @@ export function FANUC_ARC_Mate_100iD({
               <group name="M10iD_L01">
                 <mesh
                   name="Mesh_356"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.Mesh_356.geometry}
                   material={materials.Fanuc_Yellow_Textured_AO}
                 />
                 <mesh
                   name="Mesh_356_1"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.Mesh_356_1.geometry}
                   material={materials.Material_1_AO}
                 />
                 <mesh
                   name="Mesh_356_2"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.Mesh_356_2.geometry}
                   material={materials.Fanuc_BlackMetal_AO}
                 />
@@ -163,8 +139,6 @@ export function FANUC_ARC_Mate_100iD({
             </animated.group>
             <mesh
               name="M10iD_L00"
-              castShadow
-              receiveShadow
               geometry={nodes.M10iD_L00.geometry}
               material={materials.Fanuc_BlackMetal_AO}
               rotation={[-Math.PI / 2, 0, 0]}

--- a/src/components/robots/FANUC_ARC_Mate_120iD.tsx
+++ b/src/components/robots/FANUC_ARC_Mate_120iD.tsx
@@ -49,8 +49,6 @@ export function FANUC_ARC_Mate_120iD({
                         />
                         <mesh
                           name="M20iD25_L06"
-                          castShadow
-                          receiveShadow
                           geometry={nodes.M20iD25_L06.geometry}
                           material={materials.Fanuc_BlackMetal_AO}
                           position={[0, -0.09, 0]}
@@ -59,8 +57,6 @@ export function FANUC_ARC_Mate_120iD({
                       </animated.group>
                       <mesh
                         name="M20iD25_L05"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.M20iD25_L05.geometry}
                         material={materials.Fanuc_BlackMetal_AO}
                         rotation={[Math.PI, Math.PI / 2, 0]}
@@ -73,15 +69,11 @@ export function FANUC_ARC_Mate_120iD({
                     >
                       <mesh
                         name="Mesh_2"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.Mesh_2.geometry}
                         material={materials.Fanuc_Yellow_Textured_AO}
                       />
                       <mesh
                         name="Mesh_2_1"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.Mesh_2_1.geometry}
                         material={materials.Fanuc_BlackMetal_AO}
                       />
@@ -94,22 +86,16 @@ export function FANUC_ARC_Mate_120iD({
                   >
                     <mesh
                       name="Mesh_15"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.Mesh_15.geometry}
                       material={materials.Fanuc_BlackMetal_AO}
                     />
                     <mesh
                       name="Mesh_15_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.Mesh_15_1.geometry}
                       material={materials.Fanuc_Yellow_Textured_AO}
                     />
                     <mesh
                       name="Mesh_15_2"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.Mesh_15_2.geometry}
                       material={materials.Material_9_AO}
                     />
@@ -122,15 +108,11 @@ export function FANUC_ARC_Mate_120iD({
                 >
                   <mesh
                     name="Mesh_37"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.Mesh_37.geometry}
                     material={materials.Fanuc_BlackMetal_AO}
                   />
                   <mesh
                     name="Mesh_37_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.Mesh_37_1.geometry}
                     material={materials.Fanuc_Yellow_Textured_AO}
                   />
@@ -139,22 +121,16 @@ export function FANUC_ARC_Mate_120iD({
               <group name="M20iD25_L01" rotation={[-Math.PI / 2, 0, 0]}>
                 <mesh
                   name="Mesh_45"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.Mesh_45.geometry}
                   material={materials.Material_9_AO}
                 />
                 <mesh
                   name="Mesh_45_1"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.Mesh_45_1.geometry}
                   material={materials.Fanuc_Yellow_Textured_AO}
                 />
                 <mesh
                   name="Mesh_45_2"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.Mesh_45_2.geometry}
                   material={materials.Fanuc_BlackMetal_AO}
                 />
@@ -162,8 +138,6 @@ export function FANUC_ARC_Mate_120iD({
             </animated.group>
             <mesh
               name="M20iD25_L00"
-              castShadow
-              receiveShadow
               geometry={nodes.M20iD25_L00.geometry}
               material={materials.Fanuc_BlackMetal_AO}
               position={[0, -0.425, 0]}

--- a/src/components/robots/FANUC_ARC_Mate_120iD.tsx
+++ b/src/components/robots/FANUC_ARC_Mate_120iD.tsx
@@ -6,7 +6,11 @@ FANUC_ARC_Mate_120iD.config = {
   rotationOffsets: [0, Math.PI / 2, 0, 0, 0, 0],
 }
 
-export function FANUC_ARC_Mate_120iD({ modelURL, ...props }: RobotModelProps) {
+export function FANUC_ARC_Mate_120iD({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
   const nodes = gltf.nodes
   const materials = gltf.materials
@@ -38,6 +42,7 @@ export function FANUC_ARC_Mate_120iD({ modelURL, ...props }: RobotModelProps) {
                         rotation={[-Math.PI / 2, 0, 0]}
                       >
                         <group
+                          ref={flangeRef}
                           name="M20iD25_FLG"
                           position={[0, -0.09, 0]}
                           rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/FANUC_CRX10iA.tsx
+++ b/src/components/robots/FANUC_CRX10iA.tsx
@@ -47,8 +47,6 @@ export function FANUC_CRX10iA({
                       />
                       <mesh
                         name="CRX10iA_L06"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.CRX10iA_L06.geometry}
                         material={materials.Fanuc_BlackMetal}
                         position={[0, -0.16, 0]}
@@ -62,15 +60,11 @@ export function FANUC_CRX10iA({
                     >
                       <mesh
                         name="J5CASING_UNIT001"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.J5CASING_UNIT001.geometry}
                         material={materials.Fanuc_WhitePlastic}
                       />
                       <mesh
                         name="J5CASING_UNIT001_1"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.J5CASING_UNIT001_1.geometry}
                         material={materials.Fanuc_Green}
                       />
@@ -83,22 +77,16 @@ export function FANUC_CRX10iA({
                   >
                     <mesh
                       name="NAME_LABEL_CRX_10iA"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.NAME_LABEL_CRX_10iA.geometry}
                       material={materials.Fanuc_RedPlastic}
                     />
                     <mesh
                       name="NAME_LABEL_CRX_10iA_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.NAME_LABEL_CRX_10iA_1.geometry}
                       material={materials.Fanuc_BlackPlastic}
                     />
                     <mesh
                       name="NAME_LABEL_CRX_10iA_2"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.NAME_LABEL_CRX_10iA_2.geometry}
                       material={materials.Fanuc_WhitePlastic}
                     />
@@ -106,8 +94,6 @@ export function FANUC_CRX10iA({
                 </animated.group>
                 <mesh
                   name="CRX10iA_L03"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.CRX10iA_L03.geometry}
                   material={materials.Fanuc_WhitePlastic}
                   rotation={[-Math.PI / 2, 0, -Math.PI / 2]}
@@ -115,8 +101,6 @@ export function FANUC_CRX10iA({
               </animated.group>
               <mesh
                 name="CRX10iA_L02"
-                castShadow
-                receiveShadow
                 geometry={nodes.CRX10iA_L02.geometry}
                 material={materials.Fanuc_WhitePlastic}
                 rotation={[-Math.PI / 2, 0, -Math.PI / 2]}
@@ -125,22 +109,16 @@ export function FANUC_CRX10iA({
             <group name="CRX10iA_L01" position={[0, -0.117, 0]}>
               <mesh
                 name="J2BASE_UNIT001"
-                castShadow
-                receiveShadow
                 geometry={nodes.J2BASE_UNIT001.geometry}
                 material={materials.Fanuc_Green}
               />
               <mesh
                 name="J2BASE_UNIT001_1"
-                castShadow
-                receiveShadow
                 geometry={nodes.J2BASE_UNIT001_1.geometry}
                 material={materials.Fanuc_WhitePlastic}
               />
               <mesh
                 name="J2BASE_UNIT001_2"
-                castShadow
-                receiveShadow
                 geometry={nodes.J2BASE_UNIT001_2.geometry}
                 material={materials.Fanuc_GreenLED}
               />
@@ -148,8 +126,6 @@ export function FANUC_CRX10iA({
           </animated.group>
           <mesh
             name="CRX10iA_L00"
-            castShadow
-            receiveShadow
             geometry={nodes.CRX10iA_L00.geometry}
             material={materials.Fanuc_BlackMetal}
             position={[0, -0.245, 0]}

--- a/src/components/robots/FANUC_CRX10iA.tsx
+++ b/src/components/robots/FANUC_CRX10iA.tsx
@@ -6,7 +6,11 @@ FANUC_CRX10iA.config = {
   rotationOffsets: [0, Math.PI / 2, 0, 0, 0, 0],
 }
 
-export function FANUC_CRX10iA({ modelURL, ...props }: RobotModelProps) {
+export function FANUC_CRX10iA({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
   const nodes = gltf.nodes
   const materials = gltf.materials
@@ -36,6 +40,7 @@ export function FANUC_CRX10iA({ modelURL, ...props }: RobotModelProps) {
                       rotation={[-Math.PI / 2, 0, 0]}
                     >
                       <group
+                        ref={flangeRef}
                         name="CRX10iA_FLG"
                         position={[0, -0.16, 0]}
                         rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/FANUC_CRX10iAL.tsx
+++ b/src/components/robots/FANUC_CRX10iAL.tsx
@@ -21,50 +21,36 @@ export function FANUC_CRX10iAL({
         <group name="link_0">
           <mesh
             name="visuals_0"
-            castShadow
-            receiveShadow
             geometry={nodes.visuals_0.geometry}
             material={materials.fanuc_metal_black}
           />
           <mesh
             name="visuals_0_1"
-            castShadow
-            receiveShadow
             geometry={nodes.visuals_0_1.geometry}
             material={materials.fanuc_stainless_steel}
           />
           <mesh
             name="visuals_0_2"
-            castShadow
-            receiveShadow
             geometry={nodes.visuals_0_2.geometry}
             material={materials.fanuc_metal_black}
           />
           <mesh
             name="visuals_0_3"
-            castShadow
-            receiveShadow
             geometry={nodes.visuals_0_3.geometry}
             material={materials.fanuc_stainless_steel}
           />
           <mesh
             name="visuals_0_4"
-            castShadow
-            receiveShadow
             geometry={nodes.visuals_0_4.geometry}
             material={materials.fanuc_aluminium_black}
           />
           <mesh
             name="visuals_0_5"
-            castShadow
-            receiveShadow
             geometry={nodes.visuals_0_5.geometry}
             material={materials.fanuc_aluminium_black}
           />
           <mesh
             name="visuals_0_6"
-            castShadow
-            receiveShadow
             geometry={nodes.visuals_0_6.geometry}
             material={materials.fanuc_rubber}
           />
@@ -102,29 +88,21 @@ export function FANUC_CRX10iAL({
                     >
                       <mesh
                         name="visuals_6"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals_6.geometry}
                         material={materials.fanuc_metal_black}
                       />
                       <mesh
                         name="visuals_6_1"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals_6_1.geometry}
                         material={materials.fanuc_stainless_steel}
                       />
                       <mesh
                         name="visuals_6_2"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals_6_2.geometry}
                         material={materials.fanuc_aluminium_black}
                       />
                       <mesh
                         name="visuals_6_3"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals_6_3.geometry}
                         material={materials.fanuc_aluminium_black}
                       />
@@ -137,22 +115,16 @@ export function FANUC_CRX10iAL({
                   >
                     <mesh
                       name="visuals_5"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_5.geometry}
                       material={materials.fanuc_white}
                     />
                     <mesh
                       name="visuals_5_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_5_1.geometry}
                       material={materials.fanuc_green}
                     />
                     <mesh
                       name="visuals_5_2"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_5_2.geometry}
                       material={materials.fanuc_stainless_steel}
                     />
@@ -165,29 +137,21 @@ export function FANUC_CRX10iAL({
                 >
                   <mesh
                     name="visuals_4"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_4.geometry}
                     material={materials.fanuc_white}
                   />
                   <mesh
                     name="visuals_4_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_4_1.geometry}
                     material={materials.fanuc_white}
                   />
                   <mesh
                     name="visuals_4_2"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_4_2.geometry}
                     material={materials.fanuc_metal_black}
                   />
                   <mesh
                     name="visuals_4_3"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_4_3.geometry}
                     material={materials.fanuc_red}
                   />
@@ -200,15 +164,11 @@ export function FANUC_CRX10iAL({
               >
                 <mesh
                   name="visuals_3"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_3.geometry}
                   material={materials.fanuc_white}
                 />
                 <mesh
                   name="visuals_3_1"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_3_1.geometry}
                   material={materials.fanuc_green}
                 />
@@ -216,8 +176,6 @@ export function FANUC_CRX10iAL({
             </animated.group>
             <mesh
               name="link_2"
-              castShadow
-              receiveShadow
               geometry={nodes.link_2.geometry}
               material={materials.fanuc_white}
               rotation={[-Math.PI / 2, 0, -Math.PI / 2]}
@@ -226,22 +184,16 @@ export function FANUC_CRX10iAL({
           <group name="link_1">
             <mesh
               name="visuals_1"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_1.geometry}
               material={materials.fanuc_green}
             />
             <mesh
               name="visuals_1_1"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_1_1.geometry}
               material={materials.fanuc_white}
             />
             <mesh
               name="visuals_1_2"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_1_2.geometry}
               material={materials.fanuc_green}
             />

--- a/src/components/robots/FANUC_CRX10iAL.tsx
+++ b/src/components/robots/FANUC_CRX10iAL.tsx
@@ -6,7 +6,11 @@ FANUC_CRX10iAL.config = {
   rotationOffsets: [0, Math.PI / 2, 0, 0, 0, 0],
 }
 
-export function FANUC_CRX10iAL({ modelURL, ...props }: RobotModelProps) {
+export function FANUC_CRX10iAL({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
   const nodes = gltf.nodes
   const materials = gltf.materials
@@ -86,6 +90,7 @@ export function FANUC_CRX10iAL({ modelURL, ...props }: RobotModelProps) {
                     rotation={[-Math.PI / 2, 0, 0]}
                   >
                     <group
+                      ref={flangeRef}
                       name="FANUC_CRX10IAL_FLG"
                       position={[0, -0.16, 0]}
                       rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/FANUC_CRX20iAL.tsx
+++ b/src/components/robots/FANUC_CRX20iAL.tsx
@@ -21,8 +21,6 @@ export function FANUC_CRX20iAL({
         <group name="Scene">
           <mesh
             name="link_0"
-            castShadow
-            receiveShadow
             geometry={nodes.link_0.geometry}
             material={materials.fanuc_metal_black}
           />
@@ -55,8 +53,6 @@ export function FANUC_CRX20iAL({
                       />
                       <mesh
                         name="link_6"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.link_6.geometry}
                         material={materials.fanuc_metal_black}
                         position={[-0.71, 0.54, -0.15]}
@@ -70,15 +66,11 @@ export function FANUC_CRX20iAL({
                     >
                       <mesh
                         name="shape053"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.shape053.geometry}
                         material={materials.fanuc_white}
                       />
                       <mesh
                         name="shape053_1"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.shape053_1.geometry}
                         material={materials.fanuc_green}
                       />
@@ -91,22 +83,16 @@ export function FANUC_CRX20iAL({
                   >
                     <mesh
                       name="shape054"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.shape054.geometry}
                       material={materials.fanuc_white}
                     />
                     <mesh
                       name="shape054_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.shape054_1.geometry}
                       material={materials.fanuc_red}
                     />
                     <mesh
                       name="shape054_2"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.shape054_2.geometry}
                       material={materials.fanuc_metal_black}
                     />
@@ -119,15 +105,11 @@ export function FANUC_CRX20iAL({
                 >
                   <mesh
                     name="shape009"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.shape009.geometry}
                     material={materials.fanuc_green}
                   />
                   <mesh
                     name="shape009_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.shape009_1.geometry}
                     material={materials.fanuc_white}
                   />
@@ -135,8 +117,6 @@ export function FANUC_CRX20iAL({
               </animated.group>
               <mesh
                 name="link_2"
-                castShadow
-                receiveShadow
                 geometry={nodes.link_2.geometry}
                 material={materials.fanuc_white}
                 rotation={[-Math.PI / 2, 0, -Math.PI / 2]}
@@ -145,15 +125,11 @@ export function FANUC_CRX20iAL({
             <group name="link_1" position={[0, 0.245, 0]}>
               <mesh
                 name="shape005"
-                castShadow
-                receiveShadow
                 geometry={nodes.shape005.geometry}
                 material={materials.fanuc_white}
               />
               <mesh
                 name="shape005_1"
-                castShadow
-                receiveShadow
                 geometry={nodes.shape005_1.geometry}
                 material={materials.fanuc_green}
               />

--- a/src/components/robots/FANUC_CRX20iAL.tsx
+++ b/src/components/robots/FANUC_CRX20iAL.tsx
@@ -6,7 +6,11 @@ FANUC_CRX20iAL.config = {
   rotationOffsets: [0, Math.PI / 2, 0, 0, 0, 0],
 }
 
-export function FANUC_CRX20iAL({ modelURL, ...props }: RobotModelProps) {
+export function FANUC_CRX20iAL({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
   const nodes = gltf.nodes
   const materials = gltf.materials
@@ -44,6 +48,7 @@ export function FANUC_CRX20iAL({ modelURL, ...props }: RobotModelProps) {
                       rotation={[-Math.PI / 2, 0, 0]}
                     >
                       <animated.group
+                        ref={flangeRef}
                         name="FANUC_CRX20iAL_FLG"
                         position={[0, -0.16, 0]}
                         rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/FANUC_CRX25iA.tsx
+++ b/src/components/robots/FANUC_CRX25iA.tsx
@@ -6,7 +6,11 @@ FANUC_CRX25iA.config = {
   rotationOffsets: [0, Math.PI / 2, 0, 0, 0, 0],
 }
 
-export function FANUC_CRX25iA({ modelURL, ...props }: RobotModelProps) {
+export function FANUC_CRX25iA({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
   const nodes = gltf.nodes
   const materials = gltf.materials
@@ -53,6 +57,7 @@ export function FANUC_CRX25iA({ modelURL, ...props }: RobotModelProps) {
                       rotation={[-Math.PI / 2, 0, 0]}
                     >
                       <group
+                        ref={flangeRef}
                         name="CRX25iA_FLG"
                         position={[0, -0.18, 0]}
                         rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/FANUC_CRX25iA.tsx
+++ b/src/components/robots/FANUC_CRX25iA.tsx
@@ -22,15 +22,11 @@ export function FANUC_CRX25iA({
           <group name="CRX25iA_L00">
             <mesh
               name="J1BASE_NetGen_Coarse"
-              castShadow
-              receiveShadow
               geometry={nodes.J1BASE_NetGen_Coarse.geometry}
               material={materials.Fanuc_BlackMetal}
             />
             <mesh
               name="J1BASE_NetGen_Coarse_1"
-              castShadow
-              receiveShadow
               geometry={nodes.J1BASE_NetGen_Coarse_1.geometry}
               material={materials.Fanuc_GreenPlastic}
             />
@@ -64,8 +60,6 @@ export function FANUC_CRX25iA({
                       />
                       <mesh
                         name="CRX25iA_L06"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.CRX25iA_L06.geometry}
                         material={materials.Fanuc_BlackMetal}
                         position={[0, -0.18, 0]}
@@ -74,15 +68,11 @@ export function FANUC_CRX25iA({
                     <group name="CRX25iA_L05" position={[0, 0.185, 0]}>
                       <mesh
                         name="J6CASING_NetGen_Coarse"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.J6CASING_NetGen_Coarse.geometry}
                         material={materials.Fanuc_WhitePlastic}
                       />
                       <mesh
                         name="J6CASING_NetGen_Coarse_1"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.J6CASING_NetGen_Coarse_1.geometry}
                         material={materials.Fanuc_GreenPlastic}
                       />
@@ -91,22 +81,16 @@ export function FANUC_CRX25iA({
                   <group name="CRX25iA_L04" position={[0, -0.75, 0]}>
                     <mesh
                       name="J3ARM_NetGen_Coarse"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.J3ARM_NetGen_Coarse.geometry}
                       material={materials.Fanuc_WhitePlastic}
                     />
                     <mesh
                       name="J3ARM_NetGen_Coarse_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.J3ARM_NetGen_Coarse_1.geometry}
                       material={materials.Fanuc_RedPlastic}
                     />
                     <mesh
                       name="J3ARM_NetGen_Coarse_2"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.J3ARM_NetGen_Coarse_2.geometry}
                       material={materials.Fanuc_BlackPlastic}
                     />
@@ -115,15 +99,11 @@ export function FANUC_CRX25iA({
                 <group name="CRX25iA_L03">
                   <mesh
                     name="J3CASING_NetGen_Coarse"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.J3CASING_NetGen_Coarse.geometry}
                     material={materials.Fanuc_WhitePlastic}
                   />
                   <mesh
                     name="J3CASING_NetGen_Coarse_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.J3CASING_NetGen_Coarse_1.geometry}
                     material={materials.Fanuc_GreenPlastic}
                   />
@@ -131,8 +111,6 @@ export function FANUC_CRX25iA({
               </animated.group>
               <mesh
                 name="CRX25iA_L02"
-                castShadow
-                receiveShadow
                 geometry={nodes.CRX25iA_L02.geometry}
                 material={materials.Fanuc_WhitePlastic}
               />
@@ -140,15 +118,11 @@ export function FANUC_CRX25iA({
             <group name="CRX25iA_L01" position={[0, 0.18, 0]}>
               <mesh
                 name="J2BASE_NetGen_Coarse"
-                castShadow
-                receiveShadow
                 geometry={nodes.J2BASE_NetGen_Coarse.geometry}
                 material={materials.Fanuc_WhitePlastic}
               />
               <mesh
                 name="J2BASE_NetGen_Coarse_1"
-                castShadow
-                receiveShadow
                 geometry={nodes.J2BASE_NetGen_Coarse_1.geometry}
                 material={materials.Fanuc_GreenLED}
               />

--- a/src/components/robots/FANUC_CRX25iAL.tsx
+++ b/src/components/robots/FANUC_CRX25iAL.tsx
@@ -48,8 +48,6 @@ export function FANUC_CRX25iAL({
                       />
                       <mesh
                         name="CRX10iA_L06"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.CRX10iA_L06.geometry}
                         material={materials["Fanuc_BlackMetal.001"]}
                         position={[0, -0.16, 0]}
@@ -63,15 +61,11 @@ export function FANUC_CRX25iAL({
                     >
                       <mesh
                         name="J5CASING_UNIT001"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.J5CASING_UNIT001.geometry}
                         material={materials["Fanuc_WhitePlastic.001"]}
                       />
                       <mesh
                         name="J5CASING_UNIT001_1"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.J5CASING_UNIT001_1.geometry}
                         material={materials["Fanuc_Green.001"]}
                       />
@@ -84,22 +78,16 @@ export function FANUC_CRX25iAL({
                   >
                     <mesh
                       name="NAME_LABEL_CRX_10iA_L001"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.NAME_LABEL_CRX_10iA_L001.geometry}
                       material={materials["Fanuc_WhitePlastic.001"]}
                     />
                     <mesh
                       name="NAME_LABEL_CRX_10iA_L001_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.NAME_LABEL_CRX_10iA_L001_1.geometry}
                       material={materials["Fanuc_RedPlastic.001"]}
                     />
                     <mesh
                       name="NAME_LABEL_CRX_10iA_L001_2"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.NAME_LABEL_CRX_10iA_L001_2.geometry}
                       material={materials["Fanuc_BlackPlastic.001"]}
                     />
@@ -111,15 +99,11 @@ export function FANUC_CRX25iAL({
                 >
                   <mesh
                     name="J3CASING_UNIT001"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.J3CASING_UNIT001.geometry}
                     material={materials["Fanuc_WhitePlastic.001"]}
                   />
                   <mesh
                     name="J3CASING_UNIT001_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.J3CASING_UNIT001_1.geometry}
                     material={materials["Fanuc_Green.001"]}
                   />
@@ -127,8 +111,6 @@ export function FANUC_CRX25iAL({
               </animated.group>
               <mesh
                 name="CRX10iA_L02"
-                castShadow
-                receiveShadow
                 geometry={nodes.CRX10iA_L02.geometry}
                 material={materials["Fanuc_WhitePlastic.001"]}
                 rotation={[-Math.PI / 2, 0, -Math.PI / 2]}
@@ -137,22 +119,16 @@ export function FANUC_CRX25iAL({
             <group name="CRX10iA_L01" position={[0, 0.128, 0]}>
               <mesh
                 name="J2BASE_UNIT001"
-                castShadow
-                receiveShadow
                 geometry={nodes.J2BASE_UNIT001.geometry}
                 material={materials["Fanuc_WhitePlastic.001"]}
               />
               <mesh
                 name="J2BASE_UNIT001_1"
-                castShadow
-                receiveShadow
                 geometry={nodes.J2BASE_UNIT001_1.geometry}
                 material={materials["Fanuc_Green.001"]}
               />
               <mesh
                 name="J2BASE_UNIT001_2"
-                castShadow
-                receiveShadow
                 geometry={nodes.J2BASE_UNIT001_2.geometry}
                 material={materials["Fanuc_GreenLED.001"]}
               />
@@ -160,8 +136,6 @@ export function FANUC_CRX25iAL({
           </animated.group>
           <mesh
             name="CRX10iA_L00"
-            castShadow
-            receiveShadow
             geometry={nodes.CRX10iA_L00.geometry}
             material={materials["Fanuc_BlackMetal.001"]}
           />

--- a/src/components/robots/FANUC_CRX25iAL.tsx
+++ b/src/components/robots/FANUC_CRX25iAL.tsx
@@ -6,7 +6,11 @@ FANUC_CRX25iAL.config = {
   rotationOffsets: [0, Math.PI / 2, 0, 0, 0, 0],
 }
 
-export function FANUC_CRX25iAL({ modelURL, ...props }: RobotModelProps) {
+export function FANUC_CRX25iAL({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
   const nodes = gltf.nodes
   const materials = gltf.materials
@@ -37,6 +41,7 @@ export function FANUC_CRX25iAL({ modelURL, ...props }: RobotModelProps) {
                       rotation={[-Math.PI / 2, 0, 0]}
                     >
                       <group
+                        ref={flangeRef}
                         name="CRX10iA_FLG"
                         position={[0, -0.16, 0]}
                         rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/FANUC_LR_MATE_200iD7L.tsx
+++ b/src/components/robots/FANUC_LR_MATE_200iD7L.tsx
@@ -22,22 +22,16 @@ export function FANUC_LR_MATE_200iD7L({
         <group name="link_0">
           <mesh
             name="visuals_0"
-            castShadow
-            receiveShadow
             geometry={nodes.visuals_0.geometry}
             material={materials.fanuc_metal_black}
           />
           <mesh
             name="visuals_0_1"
-            castShadow
-            receiveShadow
             geometry={nodes.visuals_0_1.geometry}
             material={materials.fanuc_metal_black}
           />
           <mesh
             name="visuals_0_2"
-            castShadow
-            receiveShadow
             geometry={nodes.visuals_0_2.geometry}
             material={materials.fanuc_aluminium_black}
           />
@@ -74,8 +68,6 @@ export function FANUC_LR_MATE_200iD7L({
                     />
                     <mesh
                       name="link_6"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.link_6.geometry}
                       material={materials.fanuc_metal_black}
                       position={[-0.475, 0.47, 0]}
@@ -89,22 +81,16 @@ export function FANUC_LR_MATE_200iD7L({
                   >
                     <mesh
                       name="visuals_5"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_5.geometry}
                       material={materials.fanuc_yellow}
                     />
                     <mesh
                       name="visuals_5_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_5_1.geometry}
                       material={materials.fanuc_stainless_steel}
                     />
                     <mesh
                       name="visuals_5_2"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_5_2.geometry}
                       material={materials.fanuc_metal_black}
                     />
@@ -117,15 +103,11 @@ export function FANUC_LR_MATE_200iD7L({
                 >
                   <mesh
                     name="visuals_4"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_4.geometry}
                     material={materials.fanuc_yellow}
                   />
                   <mesh
                     name="visuals_4_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_4_1.geometry}
                     material={materials.fanuc_aluminium_black}
                   />
@@ -138,15 +120,11 @@ export function FANUC_LR_MATE_200iD7L({
               >
                 <mesh
                   name="visuals_3"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_3.geometry}
                   material={materials.fanuc_yellow}
                 />
                 <mesh
                   name="visuals_3_1"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_3_1.geometry}
                   material={materials.fanuc_stainless_steel}
                 />
@@ -154,8 +132,6 @@ export function FANUC_LR_MATE_200iD7L({
             </animated.group>
             <mesh
               name="link_2"
-              castShadow
-              receiveShadow
               geometry={nodes.link_2.geometry}
               material={materials.fanuc_yellow}
               position={[0, 0, -0.05]}
@@ -165,15 +141,11 @@ export function FANUC_LR_MATE_200iD7L({
           <group name="link_1">
             <mesh
               name="visuals_1"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_1.geometry}
               material={materials.fanuc_yellow}
             />
             <mesh
               name="visuals_1_1"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_1_1.geometry}
               material={materials.fanuc_stainless_steel}
             />

--- a/src/components/robots/FANUC_LR_MATE_200iD7L.tsx
+++ b/src/components/robots/FANUC_LR_MATE_200iD7L.tsx
@@ -10,7 +10,11 @@ FANUC_LR_MATE_200iD7L.config = {
   rotationOffsets: [0, Math.PI / 2, 0, 0, 0, 0],
 }
 
-export function FANUC_LR_MATE_200iD7L({ modelURL, ...props }: RobotModelProps) {
+export function FANUC_LR_MATE_200iD7L({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const { nodes, materials } = useGLTF(modelURL) as any
   return (
     <group {...props} dispose={null}>
@@ -63,6 +67,7 @@ export function FANUC_LR_MATE_200iD7L({ modelURL, ...props }: RobotModelProps) {
                     rotation={[-Math.PI / 2, 0, 0]}
                   >
                     <animated.group
+                      ref={flangeRef}
                       name="FANUC_LRMATE200ID7L_FLG"
                       position={[0, -0.08, 0]}
                       rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/FANUC_LR_Mate_200iD.tsx
+++ b/src/components/robots/FANUC_LR_Mate_200iD.tsx
@@ -22,15 +22,11 @@ export function FANUC_LR_Mate_200iD({
         <group name="link_0">
           <mesh
             name="shape002"
-            castShadow
-            receiveShadow
             geometry={nodes.shape002.geometry}
             material={materials.fanuc_metal_black_AO}
           />
           <mesh
             name="shape002_1"
-            castShadow
-            receiveShadow
             geometry={nodes.shape002_1.geometry}
             material={materials.fanuc_stainless_steel_AO}
           />
@@ -67,8 +63,6 @@ export function FANUC_LR_Mate_200iD({
                     />
                     <mesh
                       name="link_6"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.link_6.geometry}
                       material={materials.fanuc_metal_black_AO}
                       position={[-0.365, 0.385, 0]}
@@ -77,8 +71,6 @@ export function FANUC_LR_Mate_200iD({
                   </animated.group>
                   <mesh
                     name="link_5"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.link_5.geometry}
                     material={materials.fanuc_yellow_AO}
                     position={[-0.365, 0, -0.385]}
@@ -92,15 +84,11 @@ export function FANUC_LR_Mate_200iD({
                 >
                   <mesh
                     name="shape010"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.shape010.geometry}
                     material={materials.fanuc_yellow_AO}
                   />
                   <mesh
                     name="shape010_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.shape010_1.geometry}
                     material={materials.fanuc_aluminium_black_AO}
                   />
@@ -108,8 +96,6 @@ export function FANUC_LR_Mate_200iD({
               </animated.group>
               <mesh
                 name="link_3"
-                castShadow
-                receiveShadow
                 geometry={nodes.link_3.geometry}
                 material={materials.fanuc_yellow_AO}
                 position={[-0.33, 0, -0.05]}
@@ -118,8 +104,6 @@ export function FANUC_LR_Mate_200iD({
             </animated.group>
             <mesh
               name="link_2"
-              castShadow
-              receiveShadow
               geometry={nodes.link_2.geometry}
               material={materials.fanuc_yellow_AO}
               position={[0, 0, -0.05]}
@@ -128,8 +112,6 @@ export function FANUC_LR_Mate_200iD({
           </animated.group>
           <mesh
             name="link_1"
-            castShadow
-            receiveShadow
             geometry={nodes.link_1.geometry}
             material={materials.fanuc_yellow_AO}
           />

--- a/src/components/robots/FANUC_LR_Mate_200iD.tsx
+++ b/src/components/robots/FANUC_LR_Mate_200iD.tsx
@@ -10,7 +10,11 @@ FANUC_LR_Mate_200iD.config = {
   rotationOffsets: [0, Math.PI / 2, 0, 0, 0, 0],
 }
 
-export function FANUC_LR_Mate_200iD({ modelURL, ...props }: RobotModelProps) {
+export function FANUC_LR_Mate_200iD({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const { nodes, materials } = useGLTF(modelURL) as any
   return (
     <group {...props} dispose={null}>
@@ -56,6 +60,7 @@ export function FANUC_LR_Mate_200iD({ modelURL, ...props }: RobotModelProps) {
                     rotation={[-Math.PI / 2, 0, 0]}
                   >
                     <group
+                      ref={flangeRef}
                       name="FANUC_LRMATE-200ID_FLG"
                       position={[0, -0.08, 0]}
                       rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/KUKA_KR16_R2010_2.tsx
+++ b/src/components/robots/KUKA_KR16_R2010_2.tsx
@@ -6,7 +6,11 @@ KUKA_KR16_R2010_2.config = {
   rotationOffsets: [0, 0, -Math.PI / 2, 0, 0, 0],
 }
 
-export function KUKA_KR16_R2010_2({ modelURL, ...props }: RobotModelProps) {
+export function KUKA_KR16_R2010_2({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const { nodes, materials } = useGLTF(modelURL) as any
 
   return (
@@ -58,6 +62,7 @@ export function KUKA_KR16_R2010_2({ modelURL, ...props }: RobotModelProps) {
                     rotation={[-Math.PI / 2, 0, 0]}
                   >
                     <animated.group
+                      ref={flangeRef}
                       name="KUKA_KR16R2010_2_J05"
                       rotation={[-Math.PI / 2, 0, -Math.PI]}
                     >

--- a/src/components/robots/KUKA_KR16_R2010_2.tsx
+++ b/src/components/robots/KUKA_KR16_R2010_2.tsx
@@ -20,22 +20,16 @@ export function KUKA_KR16_R2010_2({
           <group name="link_0">
             <mesh
               name="visuals_0"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_0.geometry}
               material={materials.material_Material_Metall}
             />
             <mesh
               name="visuals_0_1"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_0_1.geometry}
               material={materials.material_Material_Farbe__2_}
             />
             <mesh
               name="visuals_0_2"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_0_2.geometry}
               material={materials.material_Material_Metall}
             />
@@ -68,8 +62,6 @@ export function KUKA_KR16_R2010_2({
                     >
                       <mesh
                         name="link_6"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.link_6.geometry}
                         material={materials.material_Material_Farbe__2_}
                         position={[0.67, 2, 0]}
@@ -78,8 +70,6 @@ export function KUKA_KR16_R2010_2({
                     </animated.group>
                     <mesh
                       name="link_5"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.link_5.geometry}
                       material={materials.material_Material_Farbe}
                       position={[-0.67, 0, 2]}
@@ -88,8 +78,6 @@ export function KUKA_KR16_R2010_2({
                   </animated.group>
                   <mesh
                     name="link_4"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.link_4.geometry}
                     material={materials.material_Material_Farbe}
                     position={[-0.67, 1.14, 0]}
@@ -103,22 +91,16 @@ export function KUKA_KR16_R2010_2({
                 >
                   <mesh
                     name="visuals_3"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_3.geometry}
                     material={materials.material_Material_Farbe}
                   />
                   <mesh
                     name="visuals_3_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_3_1.geometry}
                     material={materials.material_Material_Metall}
                   />
                   <mesh
                     name="visuals_3_2"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_3_2.geometry}
                     material={materials.material_Material_Farbe__2_}
                   />
@@ -131,15 +113,11 @@ export function KUKA_KR16_R2010_2({
               >
                 <mesh
                   name="visuals_2"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_2.geometry}
                   material={materials.material_Material_Farbe}
                 />
                 <mesh
                   name="visuals_2_1"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_2_1.geometry}
                   material={materials.material_Material_Metall}
                 />
@@ -148,22 +126,16 @@ export function KUKA_KR16_R2010_2({
             <group name="link_1">
               <mesh
                 name="visuals_1"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_1.geometry}
                 material={materials.material_Material_Farbe}
               />
               <mesh
                 name="visuals_1_1"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_1_1.geometry}
                 material={materials.material_Material_Farbe__2_}
               />
               <mesh
                 name="visuals_1_2"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_1_2.geometry}
                 material={materials.material_Material_Metall}
               />

--- a/src/components/robots/KUKA_KR210_R2700.tsx
+++ b/src/components/robots/KUKA_KR210_R2700.tsx
@@ -6,7 +6,11 @@ KUKA_KR210_R2700.config = {
   rotationOffsets: [0, 0, -Math.PI / 2, 0, 0, 0],
 }
 
-export function KUKA_KR210_R2700({ modelURL, ...props }: RobotModelProps) {
+export function KUKA_KR210_R2700({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
 
   const nodes = gltf.nodes
@@ -43,6 +47,7 @@ export function KUKA_KR210_R2700({ modelURL, ...props }: RobotModelProps) {
                         rotation={[Math.PI / 2, 0, 0]}
                       >
                         <group
+                          ref={flangeRef}
                           name="flange"
                           position={[0, -0.215, 0]}
                           rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/KUKA_KR210_R2700.tsx
+++ b/src/components/robots/KUKA_KR210_R2700.tsx
@@ -59,8 +59,6 @@ export function KUKA_KR210_R2700({
                         >
                           <mesh
                             name="visuals006"
-                            castShadow
-                            receiveShadow
                             geometry={nodes.visuals006.geometry}
                             material={materials.material_Material_Metall_black}
                           />
@@ -74,15 +72,11 @@ export function KUKA_KR210_R2700({
                         <group name="visuals005">
                           <mesh
                             name="visuals005_1"
-                            castShadow
-                            receiveShadow
                             geometry={nodes.visuals005_1.geometry}
                             material={materials.material_Material_metal_black}
                           />
                           <mesh
                             name="visuals005_2"
-                            castShadow
-                            receiveShadow
                             geometry={nodes.visuals005_2.geometry}
                             material={materials.material_Material_kuka_orange}
                           />
@@ -97,15 +91,11 @@ export function KUKA_KR210_R2700({
                       <group name="visuals004">
                         <mesh
                           name="visuals004_1"
-                          castShadow
-                          receiveShadow
                           geometry={nodes.visuals004_1.geometry}
                           material={materials.material_Material_metal_black}
                         />
                         <mesh
                           name="visuals004_2"
-                          castShadow
-                          receiveShadow
                           geometry={nodes.visuals004_2.geometry}
                           material={materials.material_Material_kuka_orange}
                         />
@@ -120,50 +110,36 @@ export function KUKA_KR210_R2700({
                     <group name="visuals003">
                       <mesh
                         name="visuals003_1"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals003_1.geometry}
                         material={materials.material_Material_rubber}
                       />
                       <mesh
                         name="visuals003_2"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals003_2.geometry}
                         material={materials.material_Material_aluminium}
                       />
                       <mesh
                         name="visuals003_3"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals003_3.geometry}
                         material={materials.material_Material_metal_black}
                       />
                       <mesh
                         name="visuals003_4"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals003_4.geometry}
                         material={materials.material_Material_kuka_black}
                       />
                       <mesh
                         name="visuals003_5"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals003_5.geometry}
                         material={materials.material_Material_Rubber_black}
                       />
                       <mesh
                         name="visuals003_6"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals003_6.geometry}
                         material={materials.material_Material_kuka_orange}
                       />
                       <mesh
                         name="visuals003_7"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals003_7.geometry}
                         material={materials.material_Material_stainless_steel}
                       />
@@ -178,22 +154,16 @@ export function KUKA_KR210_R2700({
                   <group name="visuals002">
                     <mesh
                       name="visuals002_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals002_1.geometry}
                       material={materials.material_Material_metal_black}
                     />
                     <mesh
                       name="visuals002_2"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals002_2.geometry}
                       material={materials.material_Material_Rubber_black}
                     />
                     <mesh
                       name="visuals002_3"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals002_3.geometry}
                       material={materials.material_Material_kuka_orange}
                     />
@@ -204,50 +174,36 @@ export function KUKA_KR210_R2700({
                 <group name="visuals001">
                   <mesh
                     name="visuals001_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals001_1.geometry}
                     material={materials.material_Material_kuka_black}
                   />
                   <mesh
                     name="visuals001_2"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals001_2.geometry}
                     material={materials.material_Material_kuka_orange}
                   />
                   <mesh
                     name="visuals001_3"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals001_3.geometry}
                     material={materials.material_Material_rubber}
                   />
                   <mesh
                     name="visuals001_4"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals001_4.geometry}
                     material={materials.material_Material_metal_black}
                   />
                   <mesh
                     name="visuals001_5"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals001_5.geometry}
                     material={materials.material_Material_aluminium}
                   />
                   <mesh
                     name="visuals001_6"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals001_6.geometry}
                     material={materials.material_Material_rubber_black}
                   />
                   <mesh
                     name="visuals001_7"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals001_7.geometry}
                     material={materials.material_Material_stainless_steel}
                   />
@@ -258,15 +214,11 @@ export function KUKA_KR210_R2700({
               <group name="visuals">
                 <mesh
                   name="visuals_1"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_1.geometry}
                   material={materials.material_Material_kuka_black}
                 />
                 <mesh
                   name="visuals_2"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_2.geometry}
                   material={materials.material_Material_metal_black}
                 />

--- a/src/components/robots/KUKA_KR270_R2700.tsx
+++ b/src/components/robots/KUKA_KR270_R2700.tsx
@@ -59,15 +59,11 @@ export function KUKA_KR270_R2700({
                         <group name="visuals006">
                           <mesh
                             name="visuals006_1"
-                            castShadow
-                            receiveShadow
                             geometry={nodes.visuals006_1.geometry}
                             material={materials.material_Material_Farbe__1_}
                           />
                           <mesh
                             name="visuals006_2"
-                            castShadow
-                            receiveShadow
                             geometry={nodes.visuals006_2.geometry}
                             material={materials.material_Material_Metall}
                           />
@@ -81,8 +77,6 @@ export function KUKA_KR270_R2700({
                     >
                       <mesh
                         name="visuals005"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals005.geometry}
                         material={materials.material_Material_Farbe}
                       />
@@ -95,8 +89,6 @@ export function KUKA_KR270_R2700({
                   >
                     <mesh
                       name="visuals004"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals004.geometry}
                       material={materials.material_Material_Farbe}
                     />
@@ -110,29 +102,21 @@ export function KUKA_KR270_R2700({
                   <group name="visuals003">
                     <mesh
                       name="visuals003_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals003_1.geometry}
                       material={materials.material_Material_Farbe__1_}
                     />
                     <mesh
                       name="visuals003_2"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals003_2.geometry}
                       material={materials.material_Material_Farbe__2_}
                     />
                     <mesh
                       name="visuals003_3"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals003_3.geometry}
                       material={materials.material_Material_Metall}
                     />
                     <mesh
                       name="visuals003_4"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals003_4.geometry}
                       material={materials.material_Material_Farbe}
                     />
@@ -143,29 +127,21 @@ export function KUKA_KR270_R2700({
                 <group name="visuals002">
                   <mesh
                     name="visuals002_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals002_1.geometry}
                     material={materials.material_Material_Farbe}
                   />
                   <mesh
                     name="visuals002_2"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals002_2.geometry}
                     material={materials.material_Material_Farbe__1_}
                   />
                   <mesh
                     name="visuals002_3"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals002_3.geometry}
                     material={materials.material_Material_Metall}
                   />
                   <mesh
                     name="visuals002_4"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals002_4.geometry}
                     material={materials.material_Material_Farbe__2_}
                   />
@@ -176,29 +152,21 @@ export function KUKA_KR270_R2700({
               <group name="visuals001">
                 <mesh
                   name="visuals001_1"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals001_1.geometry}
                   material={materials.material_Material_Metall}
                 />
                 <mesh
                   name="visuals001_2"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals001_2.geometry}
                   material={materials.material_Material_Farbe__1_}
                 />
                 <mesh
                   name="visuals001_3"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals001_3.geometry}
                   material={materials.material_Material_Farbe__2_}
                 />
                 <mesh
                   name="visuals001_4"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals001_4.geometry}
                   material={materials.material_Material_Farbe}
                 />
@@ -209,15 +177,11 @@ export function KUKA_KR270_R2700({
             <group name="visuals">
               <mesh
                 name="visuals_1"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_1.geometry}
                 material={materials.material_Material_Metall}
               />
               <mesh
                 name="visuals_2"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_2.geometry}
                 material={materials.material_Material_Farbe__1_}
               />

--- a/src/components/robots/KUKA_KR270_R2700.tsx
+++ b/src/components/robots/KUKA_KR270_R2700.tsx
@@ -6,7 +6,11 @@ KUKA_KR270_R2700.config = {
   rotationOffsets: [0, 0, -Math.PI / 2, 0, 0, 0],
 }
 
-export function KUKA_KR270_R2700({ modelURL, ...props }: RobotModelProps) {
+export function KUKA_KR270_R2700({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
 
   const nodes = gltf.nodes
@@ -42,6 +46,7 @@ export function KUKA_KR270_R2700({ modelURL, ...props }: RobotModelProps) {
                       rotation={[Math.PI / 2, 0, 0]}
                     >
                       <group
+                        ref={flangeRef}
                         name="flange"
                         position={[0, -0.24, 0]}
                         rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/KUKA_KR6_R700_2.tsx
+++ b/src/components/robots/KUKA_KR6_R700_2.tsx
@@ -7,7 +7,11 @@ KUKA_KR6_R700_2.config = {
   rotationSign: [-1, 1, 1, 1, 1, 1],
 }
 
-export function KUKA_KR6_R700_2({ modelURL, ...props }: RobotModelProps) {
+export function KUKA_KR6_R700_2({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const { nodes, materials } = useGLTF(modelURL) as any
   return (
     <group {...props} dispose={null}>
@@ -54,6 +58,7 @@ export function KUKA_KR6_R700_2({ modelURL, ...props }: RobotModelProps) {
                     rotation={[-Math.PI / 2, 0, -Math.PI]}
                   >
                     <group
+                      ref={flangeRef}
                       name="KUKA_KR6R700-2_FLG"
                       position={[0, -0.09, 0]}
                       rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/KUKA_KR6_R700_2.tsx
+++ b/src/components/robots/KUKA_KR6_R700_2.tsx
@@ -19,15 +19,11 @@ export function KUKA_KR6_R700_2({
         <group name="link_0">
           <mesh
             name="visuals_0"
-            castShadow
-            receiveShadow
             geometry={nodes.visuals_0.geometry}
             material={materials.kuka_metal}
           />
           <mesh
             name="visuals_0_1"
-            castShadow
-            receiveShadow
             geometry={nodes.visuals_0_1.geometry}
             material={materials.kuka_black}
           />
@@ -65,8 +61,6 @@ export function KUKA_KR6_R700_2({
                     />
                     <mesh
                       name="link_6"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.link_6.geometry}
                       material={materials.kuka_black}
                       position={[0.425, 0.725, 0]}
@@ -75,8 +69,6 @@ export function KUKA_KR6_R700_2({
                   </animated.group>
                   <mesh
                     name="link_5"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.link_5.geometry}
                     material={materials.kuka_white}
                     position={[-0.425, 0, 0.725]}
@@ -90,15 +82,11 @@ export function KUKA_KR6_R700_2({
                 >
                   <mesh
                     name="visuals_4"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_4.geometry}
                     material={materials.kuka_white}
                   />
                   <mesh
                     name="visuals_4_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_4_1.geometry}
                     material={materials.kuka_orange}
                   />
@@ -106,8 +94,6 @@ export function KUKA_KR6_R700_2({
               </animated.group>
               <mesh
                 name="link_3"
-                castShadow
-                receiveShadow
                 geometry={nodes.link_3.geometry}
                 material={materials.kuka_white}
                 position={[-0.4, 0, 0.36]}
@@ -121,15 +107,11 @@ export function KUKA_KR6_R700_2({
             >
               <mesh
                 name="visuals_2"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_2.geometry}
                 material={materials.kuka_white}
               />
               <mesh
                 name="visuals_2_1"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_2_1.geometry}
                 material={materials.kuka_orange}
               />
@@ -137,8 +119,6 @@ export function KUKA_KR6_R700_2({
           </animated.group>
           <mesh
             name="link_1"
-            castShadow
-            receiveShadow
             geometry={nodes.link_1.geometry}
             material={materials.kuka_white}
           />

--- a/src/components/robots/Robot.tsx
+++ b/src/components/robots/Robot.tsx
@@ -1,12 +1,14 @@
 import { type GroupProps } from "@react-three/fiber"
 
 import type { ConnectedMotionGroup } from "@wandelbots/wandelbots-js"
+import type { Group } from "three"
 import { defaultGetModel, SupportedRobot } from "./SupportedRobot"
 
 export type RobotProps = {
   connectedMotionGroup: ConnectedMotionGroup
   getModel?: (modelFromController: string) => string
   isGhost?: boolean
+  flangeRef?: React.MutableRefObject<Group>
 } & GroupProps
 
 /**
@@ -24,6 +26,7 @@ export function Robot({
   connectedMotionGroup,
   getModel = defaultGetModel,
   isGhost = false,
+  flangeRef,
   ...props
 }: RobotProps) {
   if (!connectedMotionGroup.dhParameters) {
@@ -39,6 +42,7 @@ export function Robot({
       dhParameters={connectedMotionGroup.dhParameters}
       getModel={getModel}
       isGhost={isGhost}
+      flangeRef={flangeRef}
       {...props}
     />
   )

--- a/src/components/robots/SupportedRobot.tsx
+++ b/src/components/robots/SupportedRobot.tsx
@@ -53,6 +53,7 @@ export type SupportedRobotProps = {
   dhParameters: DHParameter[]
   getModel?: (modelFromController: string) => string
   isGhost?: boolean
+  flangeRef?: React.MutableRefObject<THREE.Group>
 } & GroupProps
 
 export function defaultGetModel(modelFromController: string): string {
@@ -66,6 +67,7 @@ export const SupportedRobot = externalizeComponent(
     dhParameters,
     getModel = defaultGetModel,
     isGhost = false,
+    flangeRef,
     ...props
   }: SupportedRobotProps) => {
     let Robot: RobotModelComponent | null = null
@@ -276,7 +278,11 @@ export const SupportedRobot = externalizeComponent(
                 rapidlyChangingMotionState={rapidlyChangingMotionState}
                 robotConfig={Robot.config}
               >
-                <Robot modelURL={getModel(modelFromController)} {...props} />
+                <Robot
+                  modelURL={getModel(modelFromController)}
+                  flangeRef={flangeRef}
+                  {...props}
+                />
               </RobotAnimator>
             ) : (
               <DHRobot

--- a/src/components/robots/UniversalRobots_UR10CB.tsx
+++ b/src/components/robots/UniversalRobots_UR10CB.tsx
@@ -4,6 +4,7 @@ import type { RobotModelProps } from "./types"
 
 export function UniversalRobots_UR10CB({
   modelURL,
+  flangeRef,
   ...props
 }: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
@@ -273,6 +274,7 @@ export function UniversalRobots_UR10CB({
                       />
                     </group>
                     <group
+                      ref={flangeRef}
                       name="UNIVERSALROBOTS_UR10CB_FLG"
                       position={[0, 0.116, 0]}
                       rotation={[-Math.PI / 2, 0, 0]}

--- a/src/components/robots/UniversalRobots_UR10CB.tsx
+++ b/src/components/robots/UniversalRobots_UR10CB.tsx
@@ -18,15 +18,11 @@ export function UniversalRobots_UR10CB({
           <group name="link_0">
             <mesh
               name="visuals_0"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_0.geometry}
               material={materials.universalrobots_aluminum}
             />
             <mesh
               name="visuals_0_1"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_0_1.geometry}
               material={materials.universalrobots_aluminum}
             />
@@ -43,43 +39,31 @@ export function UniversalRobots_UR10CB({
             >
               <mesh
                 name="visuals_1"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_1.geometry}
                 material={materials.universalrobots_darkgrey}
               />
               <mesh
                 name="visuals_1_1"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_1_1.geometry}
                 material={materials.universalrobots_stainlesssteel}
               />
               <mesh
                 name="visuals_1_2"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_1_2.geometry}
                 material={materials.universalrobots_stainlesssteel}
               />
               <mesh
                 name="visuals_1_3"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_1_3.geometry}
                 material={materials.universalrobots_stainlesssteel}
               />
               <mesh
                 name="visuals_1_4"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_1_4.geometry}
                 material={materials.universalrobots_black}
               />
               <mesh
                 name="visuals_1_5"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_1_5.geometry}
                 material={materials.universalrobots_lightblue}
               />
@@ -95,43 +79,31 @@ export function UniversalRobots_UR10CB({
               >
                 <mesh
                   name="visuals_2"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_2.geometry}
                   material={materials.universalrobots_aluminum}
                 />
                 <mesh
                   name="visuals_2_1"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_2_1.geometry}
                   material={materials.universalrobots_stainlesssteel}
                 />
                 <mesh
                   name="visuals_2_2"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_2_2.geometry}
                   material={materials.universalrobots_darkgrey}
                 />
                 <mesh
                   name="visuals_2_3"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_2_3.geometry}
                   material={materials.universalrobots_black}
                 />
                 <mesh
                   name="visuals_2_4"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_2_4.geometry}
                   material={materials.universalrobots_stainlesssteel}
                 />
                 <mesh
                   name="visuals_2_5"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_2_5.geometry}
                   material={materials.universalrobots_lightblue}
                 />
@@ -147,36 +119,26 @@ export function UniversalRobots_UR10CB({
                 >
                   <mesh
                     name="visuals_3"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_3.geometry}
                     material={materials.universalrobots_aluminum}
                   />
                   <mesh
                     name="visuals_3_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_3_1.geometry}
                     material={materials.universalrobots_stainlesssteel}
                   />
                   <mesh
                     name="visuals_3_2"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_3_2.geometry}
                     material={materials.universalrobots_darkgrey}
                   />
                   <mesh
                     name="visuals_3_3"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_3_3.geometry}
                     material={materials.universalrobots_black}
                   />
                   <mesh
                     name="visuals_3_4"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_3_4.geometry}
                     material={materials.universalrobots_lightblue}
                   />
@@ -193,36 +155,26 @@ export function UniversalRobots_UR10CB({
                   >
                     <mesh
                       name="visuals_4"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_4.geometry}
                       material={materials.universalrobots_darkgrey}
                     />
                     <mesh
                       name="visuals_4_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_4_1.geometry}
                       material={materials.universalrobots_stainlesssteel}
                     />
                     <mesh
                       name="visuals_4_2"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_4_2.geometry}
                       material={materials.universalrobots_black}
                     />
                     <mesh
                       name="visuals_4_3"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_4_3.geometry}
                       material={materials.universalrobots_stainlesssteel}
                     />
                     <mesh
                       name="visuals_4_4"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_4_4.geometry}
                       material={materials.universalrobots_lightblue}
                     />
@@ -239,36 +191,26 @@ export function UniversalRobots_UR10CB({
                     >
                       <mesh
                         name="visuals_5"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals_5.geometry}
                         material={materials.universalrobots_darkgrey}
                       />
                       <mesh
                         name="visuals_5_1"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals_5_1.geometry}
                         material={materials.universalrobots_stainlesssteel}
                       />
                       <mesh
                         name="visuals_5_2"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals_5_2.geometry}
                         material={materials.universalrobots_black}
                       />
                       <mesh
                         name="visuals_5_3"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals_5_3.geometry}
                         material={materials.universalrobots_aluminum}
                       />
                       <mesh
                         name="visuals_5_4"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals_5_4.geometry}
                         material={materials.universalrobots_lightblue}
                       />
@@ -282,15 +224,11 @@ export function UniversalRobots_UR10CB({
                       <group name="link_6" position={[1.184, -0.012, -0.28]}>
                         <mesh
                           name="visuals_6"
-                          castShadow
-                          receiveShadow
                           geometry={nodes.visuals_6.geometry}
                           material={materials.universalrobots_aluminum}
                         />
                         <mesh
                           name="visuals_6_1"
-                          castShadow
-                          receiveShadow
                           geometry={nodes.visuals_6_1.geometry}
                           material={materials.universalrobots_aluminum}
                         />

--- a/src/components/robots/UniversalRobots_UR10e.tsx
+++ b/src/components/robots/UniversalRobots_UR10e.tsx
@@ -2,7 +2,11 @@ import { animated } from "@react-spring/three"
 import { useGLTF } from "@react-three/drei"
 import type { RobotModelProps } from "./types"
 
-export function UniversalRobots_UR10e({ modelURL, ...props }: RobotModelProps) {
+export function UniversalRobots_UR10e({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
   const nodes = gltf.nodes
   const materials = gltf.materials
@@ -31,6 +35,7 @@ export function UniversalRobots_UR10e({ modelURL, ...props }: RobotModelProps) {
                         rotation={[-Math.PI / 2, 0, 0]}
                       >
                         <animated.group
+                          ref={flangeRef}
                           name="UR10e_FLG"
                           position={[1.184, -0.174, 0.061]}
                           rotation={[-Math.PI / 2, 0, 0]}

--- a/src/components/robots/UniversalRobots_UR10e.tsx
+++ b/src/components/robots/UniversalRobots_UR10e.tsx
@@ -44,15 +44,11 @@ export function UniversalRobots_UR10e({
                             name="C-1000493"
                             geometry={nodes["C-1000493"].geometry}
                             material={materials.Black}
-                            castShadow
-                            receiveShadow
                           />
                           <mesh
                             name="C-1000493_1"
                             geometry={nodes["C-1000493_1"].geometry}
                             material={materials.Metal}
-                            castShadow
-                            receiveShadow
                           />
                         </animated.group>
 
@@ -70,29 +66,21 @@ export function UniversalRobots_UR10e({
                           name="C-1000492"
                           geometry={nodes["C-1000492"].geometry}
                           material={materials.DarkGray}
-                          castShadow
-                          receiveShadow
                         />
                         <mesh
                           name="C-1000492_1"
                           geometry={nodes["C-1000492_1"].geometry}
                           material={materials.Black}
-                          castShadow
-                          receiveShadow
                         />
                         <mesh
                           name="C-1000492_2"
                           geometry={nodes["C-1000492_2"].geometry}
                           material={materials.Blue}
-                          castShadow
-                          receiveShadow
                         />
                         <mesh
                           name="C-1000492_3"
                           geometry={nodes["C-1000492_3"].geometry}
                           material={materials.Screw}
-                          castShadow
-                          receiveShadow
                         />
                       </group>
                     </animated.group>
@@ -105,29 +93,21 @@ export function UniversalRobots_UR10e({
                         name="C-1000491"
                         geometry={nodes["C-1000491"].geometry}
                         material={materials.DarkGray}
-                        castShadow
-                        receiveShadow
                       />
                       <mesh
                         name="C-1000491_1"
                         geometry={nodes["C-1000491_1"].geometry}
                         material={materials.Blue}
-                        castShadow
-                        receiveShadow
                       />
                       <mesh
                         name="C-1000491_2"
                         geometry={nodes["C-1000491_2"].geometry}
                         material={materials.Black}
-                        castShadow
-                        receiveShadow
                       />
                       <mesh
                         name="C-1000491_3"
                         geometry={nodes["C-1000491_3"].geometry}
                         material={materials.Screw}
-                        castShadow
-                        receiveShadow
                       />
                     </group>
                   </animated.group>
@@ -140,29 +120,21 @@ export function UniversalRobots_UR10e({
                       name="C-1000490"
                       geometry={nodes["C-1000490"].geometry}
                       material={materials.Metal}
-                      castShadow
-                      receiveShadow
                     />
                     <mesh
                       name="C-1000490_1"
                       geometry={nodes["C-1000490_1"].geometry}
                       material={materials.Black}
-                      castShadow
-                      receiveShadow
                     />
                     <mesh
                       name="C-1000490_2"
                       geometry={nodes["C-1000490_2"].geometry}
                       material={materials.DarkGray}
-                      castShadow
-                      receiveShadow
                     />
                     <mesh
                       name="C-1000490_3"
                       geometry={nodes["C-1000490_3"].geometry}
                       material={materials.Blue}
-                      castShadow
-                      receiveShadow
                     />
                   </group>
                 </animated.group>
@@ -175,36 +147,26 @@ export function UniversalRobots_UR10e({
                     name="C-1000489"
                     geometry={nodes["C-1000489"].geometry}
                     material={materials.Blue}
-                    castShadow
-                    receiveShadow
                   />
                   <mesh
                     name="C-1000489_1"
                     geometry={nodes["C-1000489_1"].geometry}
                     material={materials.Black}
-                    castShadow
-                    receiveShadow
                   />
                   <mesh
                     name="C-1000489_2"
                     geometry={nodes["C-1000489_2"].geometry}
                     material={materials.DarkGray}
-                    castShadow
-                    receiveShadow
                   />
                   <mesh
                     name="C-1000489_3"
                     geometry={nodes["C-1000489_3"].geometry}
                     material={materials.Screw}
-                    castShadow
-                    receiveShadow
                   />
                   <mesh
                     name="C-1000489_4"
                     geometry={nodes["C-1000489_4"].geometry}
                     material={materials.Metal}
-                    castShadow
-                    receiveShadow
                   />
                 </animated.group>
               </animated.group>
@@ -213,29 +175,21 @@ export function UniversalRobots_UR10e({
                   name="C-1000488"
                   geometry={nodes["C-1000488"].geometry}
                   material={materials.Black}
-                  castShadow
-                  receiveShadow
                 />
                 <mesh
                   name="C-1000488_1"
                   geometry={nodes["C-1000488_1"].geometry}
                   material={materials.Blue}
-                  castShadow
-                  receiveShadow
                 />
                 <mesh
                   name="C-1000488_2"
                   geometry={nodes["C-1000488_2"].geometry}
                   material={materials.Screw}
-                  castShadow
-                  receiveShadow
                 />
                 <mesh
                   name="C-1000488_3"
                   geometry={nodes["C-1000488_3"].geometry}
                   material={materials.DarkGray}
-                  castShadow
-                  receiveShadow
                 />
               </group>
             </animated.group>
@@ -244,15 +198,11 @@ export function UniversalRobots_UR10e({
                 name="C-1000487"
                 geometry={nodes["C-1000487"].geometry}
                 material={materials.Black}
-                castShadow
-                receiveShadow
               />
               <mesh
                 name="C-1000487_1"
                 geometry={nodes["C-1000487_1"].geometry}
                 material={materials.Metal}
-                castShadow
-                receiveShadow
               />
             </group>
           </group>

--- a/src/components/robots/UniversalRobots_UR3CB.tsx
+++ b/src/components/robots/UniversalRobots_UR3CB.tsx
@@ -2,7 +2,11 @@ import { animated } from "@react-spring/three"
 import { useGLTF } from "@react-three/drei"
 import type { RobotModelProps } from "./types"
 
-export function UniversalRobots_UR3CB({ modelURL, ...props }: RobotModelProps) {
+export function UniversalRobots_UR3CB({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
   const nodes = gltf.nodes
   const materials = gltf.materials
@@ -37,7 +41,11 @@ export function UniversalRobots_UR3CB({ modelURL, ...props }: RobotModelProps) {
                         position={[0, 0.085, 0]}
                         rotation={[-Math.PI / 2, 0, 0]}
                       >
-                        <group name="UR3_FLG" position={[0, 0.082, 0]} />
+                        <group
+                          ref={flangeRef}
+                          name="UR3_FLG"
+                          position={[0, 0.082, 0]}
+                        />
                         <mesh
                           name="UR3_L06"
                           castShadow

--- a/src/components/robots/UniversalRobots_UR3CB.tsx
+++ b/src/components/robots/UniversalRobots_UR3CB.tsx
@@ -31,8 +31,6 @@ export function UniversalRobots_UR3CB({
                     >
                       <mesh
                         name="UR3_05"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.UR3_05.geometry}
                         material={materials.Standard}
                       />
@@ -48,8 +46,6 @@ export function UniversalRobots_UR3CB({
                         />
                         <mesh
                           name="UR3_L06"
-                          castShadow
-                          receiveShadow
                           geometry={nodes.UR3_L06.geometry}
                           material={materials.Standard}
                         />
@@ -57,40 +53,30 @@ export function UniversalRobots_UR3CB({
                     </animated.group>
                     <mesh
                       name="UR3_L04"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.UR3_L04.geometry}
                       material={materials.Standard}
                     />
                   </animated.group>
                   <mesh
                     name="UR3_L03"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.UR3_L03.geometry}
                     material={materials.Standard}
                   />
                 </animated.group>
                 <mesh
                   name="UR3_L02"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.UR3_L02.geometry}
                   material={materials.Standard}
                 />
               </animated.group>
               <mesh
                 name="UR3_L01"
-                castShadow
-                receiveShadow
                 geometry={nodes.UR3_L01.geometry}
                 material={materials.Standard}
               />
             </animated.group>
             <mesh
               name="UR3_L00"
-              castShadow
-              receiveShadow
               geometry={nodes.UR3_L00.geometry}
               material={materials.Standard}
               rotation={[-Math.PI / 2, 0, 0]}

--- a/src/components/robots/UniversalRobots_UR3e.tsx
+++ b/src/components/robots/UniversalRobots_UR3e.tsx
@@ -17,15 +17,11 @@ export function UniversalRobots_UR3e({
         <group name="link_0">
           <mesh
             name="visuals_0"
-            castShadow
-            receiveShadow
             geometry={nodes.visuals_0.geometry}
             material={materials.universalrobots_black}
           />
           <mesh
             name="visuals_0_1"
-            castShadow
-            receiveShadow
             geometry={nodes.visuals_0_1.geometry}
             material={materials.universalrobots_aluminum}
           />
@@ -34,36 +30,26 @@ export function UniversalRobots_UR3e({
           <group name="link_1">
             <mesh
               name="visuals_1"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_1.geometry}
               material={materials.universalrobots_black}
             />
             <mesh
               name="visuals_1_1"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_1_1.geometry}
               material={materials.universalrobots_darkgrey}
             />
             <mesh
               name="visuals_1_2"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_1_2.geometry}
               material={materials.universalrobots_lightblue}
             />
             <mesh
               name="visuals_1_3"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_1_3.geometry}
               material={materials.universalrobots_black}
             />
             <mesh
               name="visuals_1_4"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_1_4.geometry}
               material={materials.universalrobots_stainlesssteel}
             />
@@ -80,29 +66,21 @@ export function UniversalRobots_UR3e({
             >
               <mesh
                 name="visuals_2"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_2.geometry}
                 material={materials.universalrobots_black}
               />
               <mesh
                 name="visuals_2_1"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_2_1.geometry}
                 material={materials.universalrobots_aluminum}
               />
               <mesh
                 name="visuals_2_2"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_2_2.geometry}
                 material={materials.universalrobots_darkgrey}
               />
               <mesh
                 name="visuals_2_3"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_2_3.geometry}
                 material={materials.universalrobots_lightblue}
               />
@@ -118,29 +96,21 @@ export function UniversalRobots_UR3e({
               >
                 <mesh
                   name="visuals_3"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_3.geometry}
                   material={materials.universalrobots_black}
                 />
                 <mesh
                   name="visuals_3_1"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_3_1.geometry}
                   material={materials.universalrobots_aluminum}
                 />
                 <mesh
                   name="visuals_3_2"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_3_2.geometry}
                   material={materials.universalrobots_darkgrey}
                 />
                 <mesh
                   name="visuals_3_3"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_3_3.geometry}
                   material={materials.universalrobots_lightblue}
                 />
@@ -156,22 +126,16 @@ export function UniversalRobots_UR3e({
                 >
                   <mesh
                     name="visuals_4"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_4.geometry}
                     material={materials.universalrobots_black}
                   />
                   <mesh
                     name="visuals_4_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_4_1.geometry}
                     material={materials.universalrobots_darkgrey}
                   />
                   <mesh
                     name="visuals_4_2"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_4_2.geometry}
                     material={materials.universalrobots_lightblue}
                   />
@@ -188,22 +152,16 @@ export function UniversalRobots_UR3e({
                   >
                     <mesh
                       name="visuals_5"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_5.geometry}
                       material={materials.universalrobots_black}
                     />
                     <mesh
                       name="visuals_5_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_5_1.geometry}
                       material={materials.universalrobots_darkgrey}
                     />
                     <mesh
                       name="visuals_5_2"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_5_2.geometry}
                       material={materials.universalrobots_lightblue}
                     />
@@ -220,22 +178,16 @@ export function UniversalRobots_UR3e({
                     >
                       <mesh
                         name="visuals_6"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals_6.geometry}
                         material={materials.universalrobots_stainlesssteel}
                       />
                       <mesh
                         name="visuals_6_1"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals_6_1.geometry}
                         material={materials.universalrobots_black}
                       />
                       <mesh
                         name="visuals_6_2"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.visuals_6_2.geometry}
                         material={materials.universalrobots_aluminum}
                       />

--- a/src/components/robots/UniversalRobots_UR3e.tsx
+++ b/src/components/robots/UniversalRobots_UR3e.tsx
@@ -2,7 +2,11 @@ import { animated } from "@react-spring/three"
 import { useGLTF } from "@react-three/drei"
 import type { RobotModelProps } from "./types"
 
-export function UniversalRobots_UR3e({ modelURL, ...props }: RobotModelProps) {
+export function UniversalRobots_UR3e({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
   const nodes = gltf.nodes
   const materials = gltf.materials
@@ -237,6 +241,7 @@ export function UniversalRobots_UR3e({ modelURL, ...props }: RobotModelProps) {
                       />
                     </group>
                     <group
+                      ref={flangeRef}
                       name="UNIVERSALROBOTS_UR3E_FLG"
                       position={[0, 0.092, 0]}
                     />

--- a/src/components/robots/UniversalRobots_UR5CB.tsx
+++ b/src/components/robots/UniversalRobots_UR5CB.tsx
@@ -2,7 +2,11 @@ import { animated } from "@react-spring/three"
 import { useGLTF } from "@react-three/drei"
 import type { RobotModelProps } from "./types"
 
-export function UniversalRobots_UR5CB({ modelURL, ...props }: RobotModelProps) {
+export function UniversalRobots_UR5CB({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
   const nodes = gltf.nodes
   const materials = gltf.materials
@@ -224,6 +228,7 @@ export function UniversalRobots_UR5CB({ modelURL, ...props }: RobotModelProps) {
                       rotation={[-Math.PI / 2, 0, 0]}
                     />
                     <group
+                      ref={flangeRef}
                       name="UNIVERSALROBOTS_UR5CB_FLG"
                       position={[0, 0.082, 0]}
                     />

--- a/src/components/robots/UniversalRobots_UR5CB.tsx
+++ b/src/components/robots/UniversalRobots_UR5CB.tsx
@@ -18,29 +18,21 @@ export function UniversalRobots_UR5CB({
           <group name="link_1">
             <mesh
               name="visuals_1"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_1.geometry}
               material={materials.universalrobots_darkgrey}
             />
             <mesh
               name="visuals_1_1"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_1_1.geometry}
               material={materials.universalrobots_black}
             />
             <mesh
               name="visuals_1_2"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_1_2.geometry}
               material={materials.universalrobots_aluminum}
             />
             <mesh
               name="visuals_1_3"
-              castShadow
-              receiveShadow
               geometry={nodes.visuals_1_3.geometry}
               material={materials.universalrobots_lightblue}
             />
@@ -57,36 +49,26 @@ export function UniversalRobots_UR5CB({
             >
               <mesh
                 name="visuals_2"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_2.geometry}
                 material={materials.universalrobots_stainlesssteel}
               />
               <mesh
                 name="visuals_2_1"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_2_1.geometry}
                 material={materials.universalrobots_lightblue}
               />
               <mesh
                 name="visuals_2_2"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_2_2.geometry}
                 material={materials.universalrobots_aluminum}
               />
               <mesh
                 name="visuals_2_3"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_2_3.geometry}
                 material={materials.universalrobots_black}
               />
               <mesh
                 name="visuals_2_4"
-                castShadow
-                receiveShadow
                 geometry={nodes.visuals_2_4.geometry}
                 material={materials.universalrobots_darkgrey}
               />
@@ -102,36 +84,26 @@ export function UniversalRobots_UR5CB({
               >
                 <mesh
                   name="visuals_3"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_3.geometry}
                   material={materials.universalrobots_lightblue}
                 />
                 <mesh
                   name="visuals_3_1"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_3_1.geometry}
                   material={materials.universalrobots_black}
                 />
                 <mesh
                   name="visuals_3_2"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_3_2.geometry}
                   material={materials.universalrobots_aluminum}
                 />
                 <mesh
                   name="visuals_3_3"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_3_3.geometry}
                   material={materials.universalrobots_darkgrey}
                 />
                 <mesh
                   name="visuals_3_4"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.visuals_3_4.geometry}
                   material={materials.universalrobots_stainlesssteel}
                 />
@@ -147,29 +119,21 @@ export function UniversalRobots_UR5CB({
                 >
                   <mesh
                     name="visuals_4"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_4.geometry}
                     material={materials.universalrobots_darkgrey}
                   />
                   <mesh
                     name="visuals_4_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_4_1.geometry}
                     material={materials.universalrobots_aluminum}
                   />
                   <mesh
                     name="visuals_4_2"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_4_2.geometry}
                     material={materials.universalrobots_lightblue}
                   />
                   <mesh
                     name="visuals_4_3"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.visuals_4_3.geometry}
                     material={materials.universalrobots_black}
                   />
@@ -186,29 +150,21 @@ export function UniversalRobots_UR5CB({
                   >
                     <mesh
                       name="visuals_5"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_5.geometry}
                       material={materials.universalrobots_darkgrey}
                     />
                     <mesh
                       name="visuals_5_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_5_1.geometry}
                       material={materials.universalrobots_lightblue}
                     />
                     <mesh
                       name="visuals_5_2"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_5_2.geometry}
                       material={materials.universalrobots_aluminum}
                     />
                     <mesh
                       name="visuals_5_3"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.visuals_5_3.geometry}
                       material={materials.universalrobots_black}
                     />
@@ -220,8 +176,6 @@ export function UniversalRobots_UR5CB({
                   >
                     <mesh
                       name="link_6"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.link_6.geometry}
                       material={materials.universalrobots_stainlesssteel}
                       position={[0.817, -0.109, -0.005]}
@@ -240,8 +194,6 @@ export function UniversalRobots_UR5CB({
         </animated.group>
         <mesh
           name="link_0"
-          castShadow
-          receiveShadow
           geometry={nodes.link_0.geometry}
           material={materials.universalrobots_aluminum}
         />

--- a/src/components/robots/UniversalRobots_UR5e.tsx
+++ b/src/components/robots/UniversalRobots_UR5e.tsx
@@ -2,7 +2,11 @@ import { animated } from "@react-spring/three"
 import { useGLTF } from "@react-three/drei"
 import type { RobotModelProps } from "./types"
 
-export function UniversalRobots_UR5e({ modelURL, ...props }: RobotModelProps) {
+export function UniversalRobots_UR5e({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
   const nodes = gltf.nodes
   const materials = gltf.materials
@@ -30,7 +34,11 @@ export function UniversalRobots_UR5e({ modelURL, ...props }: RobotModelProps) {
                         position={[0, 0.1, 0]}
                         rotation={[-Math.PI / 2, 0, 0]}
                       >
-                        <group name="UR5e_FLG" position={[0, 0.1, 0]}></group>
+                        <group
+                          ref={flangeRef}
+                          name="UR5e_FLG"
+                          position={[0, 0.1, 0]}
+                        ></group>
 
                         <group
                           name="UR5e_L06"

--- a/src/components/robots/UniversalRobots_UR5e.tsx
+++ b/src/components/robots/UniversalRobots_UR5e.tsx
@@ -48,15 +48,11 @@ export function UniversalRobots_UR5e({
                           <>
                             <mesh
                               name="C-1000255"
-                              castShadow
-                              receiveShadow
                               geometry={nodes["C-1000255"].geometry}
                               material={materials.Black}
                             />
                             <mesh
                               name="C-1000255_1"
-                              castShadow
-                              receiveShadow
                               geometry={nodes["C-1000255_1"].geometry}
                               material={materials.Metal}
                             />
@@ -70,29 +66,21 @@ export function UniversalRobots_UR5e({
                         <>
                           <mesh
                             name="C-1000253"
-                            castShadow
-                            receiveShadow
                             geometry={nodes["C-1000253"].geometry}
                             material={materials.Blue}
                           />
                           <mesh
                             name="C-1000253_1"
-                            castShadow
-                            receiveShadow
                             geometry={nodes["C-1000253_1"].geometry}
                             material={materials.Black}
                           />
                           <mesh
                             name="C-1000253_2"
-                            castShadow
-                            receiveShadow
                             geometry={nodes["C-1000253_2"].geometry}
                             material={materials.Metal}
                           />
                           <mesh
                             name="C-1000253_3"
-                            castShadow
-                            receiveShadow
                             geometry={nodes["C-1000253_3"].geometry}
                             material={materials.DarkGray}
                           />
@@ -103,29 +91,21 @@ export function UniversalRobots_UR5e({
                       <>
                         <mesh
                           name="C-1000251"
-                          castShadow
-                          receiveShadow
                           geometry={nodes["C-1000251"].geometry}
                           material={materials.Blue}
                         />
                         <mesh
                           name="C-1000251_1"
-                          castShadow
-                          receiveShadow
                           geometry={nodes["C-1000251_1"].geometry}
                           material={materials.Black}
                         />
                         <mesh
                           name="C-1000251_2"
-                          castShadow
-                          receiveShadow
                           geometry={nodes["C-1000251_2"].geometry}
                           material={materials.Metal}
                         />
                         <mesh
                           name="C-1000251_3"
-                          castShadow
-                          receiveShadow
                           geometry={nodes["C-1000251_3"].geometry}
                           material={materials.DarkGray}
                         />
@@ -136,36 +116,26 @@ export function UniversalRobots_UR5e({
                     <>
                       <mesh
                         name="C-1000250"
-                        castShadow
-                        receiveShadow
                         geometry={nodes["C-1000250"].geometry}
                         material={materials.Black}
                       />
                       <mesh
                         name="C-1000250_1"
-                        castShadow
-                        receiveShadow
                         geometry={nodes["C-1000250_1"].geometry}
                         material={materials.DarkGray}
                       />
                       <mesh
                         name="C-1000250_2"
-                        castShadow
-                        receiveShadow
                         geometry={nodes["C-1000250_2"].geometry}
                         material={materials.Blue}
                       />
                       <mesh
                         name="C-1000250_3"
-                        castShadow
-                        receiveShadow
                         geometry={nodes["C-1000250_3"].geometry}
                         material={materials.Metal}
                       />
                       <mesh
                         name="C-1000250_4"
-                        castShadow
-                        receiveShadow
                         geometry={nodes["C-1000250_4"].geometry}
                         material={materials.Metal}
                       />
@@ -176,36 +146,26 @@ export function UniversalRobots_UR5e({
                   <>
                     <mesh
                       name="C-1000249"
-                      castShadow
-                      receiveShadow
                       geometry={nodes["C-1000249"].geometry}
                       material={materials.Metal}
                     />
                     <mesh
                       name="C-1000249_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes["C-1000249_1"].geometry}
                       material={materials.Black}
                     />
                     <mesh
                       name="C-1000249_2"
-                      castShadow
-                      receiveShadow
                       geometry={nodes["C-1000249_2"].geometry}
                       material={materials.DarkGray}
                     />
                     <mesh
                       name="C-1000249_3"
-                      castShadow
-                      receiveShadow
                       geometry={nodes["C-1000249_3"].geometry}
                       material={materials.Blue}
                     />
                     <mesh
                       name="C-1000249_4"
-                      castShadow
-                      receiveShadow
                       geometry={nodes["C-1000249_4"].geometry}
                       material={materials.Metal}
                     />
@@ -216,29 +176,21 @@ export function UniversalRobots_UR5e({
                 <>
                   <mesh
                     name="C-1000248"
-                    castShadow
-                    receiveShadow
                     geometry={nodes["C-1000248"].geometry}
                     material={materials.DarkGray}
                   />
                   <mesh
                     name="C-1000248_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes["C-1000248_1"].geometry}
                     material={materials.Black}
                   />
                   <mesh
                     name="C-1000248_2"
-                    castShadow
-                    receiveShadow
                     geometry={nodes["C-1000248_2"].geometry}
                     material={materials.Blue}
                   />
                   <mesh
                     name="C-1000248_3"
-                    castShadow
-                    receiveShadow
                     geometry={nodes["C-1000248_3"].geometry}
                     material={materials.Metal}
                   />
@@ -249,15 +201,11 @@ export function UniversalRobots_UR5e({
               <>
                 <mesh
                   name="C-1000257"
-                  castShadow
-                  receiveShadow
                   geometry={nodes["C-1000257"].geometry}
                   material={materials.Black}
                 />
                 <mesh
                   name="C-1000257_1"
-                  castShadow
-                  receiveShadow
                   geometry={nodes["C-1000257_1"].geometry}
                   material={materials.Metal}
                 />

--- a/src/components/robots/Yaskawa_AR1440.tsx
+++ b/src/components/robots/Yaskawa_AR1440.tsx
@@ -7,7 +7,11 @@ Yaskawa_AR1440.config = {
   rotationSign: [1, -1, 1, 1, 1, 1],
 }
 
-export function Yaskawa_AR1440({ modelURL, ...props }: RobotModelProps) {
+export function Yaskawa_AR1440({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
 
   const nodes = gltf.nodes
@@ -44,6 +48,7 @@ export function Yaskawa_AR1440({ modelURL, ...props }: RobotModelProps) {
                         rotation={[-Math.PI / 2, 0, 0]}
                       >
                         <group
+                          ref={flangeRef}
                           name="AR1440_FLG"
                           position={[0, -0.1, 0]}
                           rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/Yaskawa_AR1440.tsx
+++ b/src/components/robots/Yaskawa_AR1440.tsx
@@ -55,16 +55,12 @@ export function Yaskawa_AR1440({
                         ></group>
                         <mesh
                           name="AR1440_L06_CAD"
-                          castShadow
-                          receiveShadow
                           geometry={nodes.AR1440_L06_CAD.geometry}
                           material={materials.metall}
                         />
                       </animated.group>
                       <mesh
                         name="AR1440_L05_CAD"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.AR1440_L05_CAD.geometry}
                         material={materials.yaskawaBlueMetall}
                       />
@@ -72,15 +68,11 @@ export function Yaskawa_AR1440({
                     <group name="AR1440_L04_CAD">
                       <mesh
                         name="AR1440_L04_CAD001"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.AR1440_L04_CAD001.geometry}
                         material={materials.yaskawaBlueMetall}
                       />
                       <mesh
                         name="AR1440_L04_CAD001_1"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.AR1440_L04_CAD001_1.geometry}
                         material={materials.white}
                       />
@@ -89,15 +81,11 @@ export function Yaskawa_AR1440({
                   <group name="AR1440_L03_CAD">
                     <mesh
                       name="AR1440_L03_CAD001"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.AR1440_L03_CAD001.geometry}
                       material={materials.yaskawaBlueMetall}
                     />
                     <mesh
                       name="AR1440_L03_CAD001_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.AR1440_L03_CAD001_1.geometry}
                       material={materials.blackMetall}
                     />
@@ -105,8 +93,6 @@ export function Yaskawa_AR1440({
                 </animated.group>
                 <mesh
                   name="AR1440_L02_CAD"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.AR1440_L02_CAD.geometry}
                   material={materials.yaskawaBlueMetall}
                 />
@@ -114,15 +100,11 @@ export function Yaskawa_AR1440({
               <group name="AR1440_L01_CAD">
                 <mesh
                   name="AR1440_L01_CAD001"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.AR1440_L01_CAD001.geometry}
                   material={materials.yaskawaBlueMetall}
                 />
                 <mesh
                   name="AR1440_L01_CAD001_1"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.AR1440_L01_CAD001_1.geometry}
                   material={materials.blackMetall}
                 />
@@ -130,8 +112,6 @@ export function Yaskawa_AR1440({
             </animated.group>
             <mesh
               name="AR1440_L00_CAD"
-              castShadow
-              receiveShadow
               geometry={nodes.AR1440_L00_CAD.geometry}
               material={materials.yaskawaBlueMetall}
               position={[0, 0, 0.45]}

--- a/src/components/robots/Yaskawa_AR1730.tsx
+++ b/src/components/robots/Yaskawa_AR1730.tsx
@@ -7,7 +7,11 @@ Yaskawa_AR1730.config = {
   rotationSign: [1, -1, 1, 1, 1, 1],
 }
 
-export function Yaskawa_AR1730({ modelURL, ...props }: RobotModelProps) {
+export function Yaskawa_AR1730({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
 
   const nodes = gltf.nodes
@@ -43,6 +47,7 @@ export function Yaskawa_AR1730({ modelURL, ...props }: RobotModelProps) {
                       rotation={[-Math.PI / 2, 0, 0]}
                     >
                       <group
+                        ref={flangeRef}
                         name="AR1730_FLG"
                         position={[0, -0.1, 0]}
                         rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/Yaskawa_AR1730.tsx
+++ b/src/components/robots/Yaskawa_AR1730.tsx
@@ -54,8 +54,6 @@ export function Yaskawa_AR1730({
                       />
                       <mesh
                         name="AR1730_L06"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.AR1730_L06.geometry}
                         material={materials.Metal}
                         rotation={[Math.PI / 2, -Math.PI / 2, 0]}
@@ -63,8 +61,6 @@ export function Yaskawa_AR1730({
                     </animated.group>
                     <mesh
                       name="AR1730_L05"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.AR1730_L05.geometry}
                       material={materials.Blue}
                       rotation={[Math.PI / 2, 0, Math.PI / 2]}
@@ -77,15 +73,11 @@ export function Yaskawa_AR1730({
                   >
                     <mesh
                       name="_R_AXIS_SW0001002"
-                      castShadow
-                      receiveShadow
                       geometry={nodes._R_AXIS_SW0001002.geometry}
                       material={materials.Blue}
                     />
                     <mesh
                       name="_R_AXIS_SW0001002_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes._R_AXIS_SW0001002_1.geometry}
                       material={materials.White}
                     />
@@ -97,15 +89,11 @@ export function Yaskawa_AR1730({
                 >
                   <mesh
                     name="_U_AXIS_SW0001002"
-                    castShadow
-                    receiveShadow
                     geometry={nodes._U_AXIS_SW0001002.geometry}
                     material={materials.Blue}
                   />
                   <mesh
                     name="_U_AXIS_SW0001002_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes._U_AXIS_SW0001002_1.geometry}
                     material={materials.Black}
                   />
@@ -113,8 +101,6 @@ export function Yaskawa_AR1730({
               </animated.group>
               <mesh
                 name="AR1730_L02"
-                castShadow
-                receiveShadow
                 geometry={nodes.AR1730_L02.geometry}
                 material={materials.Blue}
                 position={[0, -0.157, 0]}
@@ -128,15 +114,11 @@ export function Yaskawa_AR1730({
             >
               <mesh
                 name="_S_AXIS_SW0001002"
-                castShadow
-                receiveShadow
                 geometry={nodes._S_AXIS_SW0001002.geometry}
                 material={materials.Blue}
               />
               <mesh
                 name="_S_AXIS_SW0001002_1"
-                castShadow
-                receiveShadow
                 geometry={nodes._S_AXIS_SW0001002_1.geometry}
                 material={materials.Black}
               />
@@ -144,8 +126,6 @@ export function Yaskawa_AR1730({
           </animated.group>
           <mesh
             name="AR1730_L00"
-            castShadow
-            receiveShadow
             geometry={nodes.AR1730_L00.geometry}
             material={materials.Blue}
             position={[0, -0.505, 0]}

--- a/src/components/robots/Yaskawa_AR2010.tsx
+++ b/src/components/robots/Yaskawa_AR2010.tsx
@@ -6,7 +6,11 @@ Yaskawa_AR2010.config = {
   rotationOffsets: [0, -Math.PI / 2, 0, 0, 0, 0],
 }
 
-export function Yaskawa_AR2010({ modelURL, ...props }: RobotModelProps) {
+export function Yaskawa_AR2010({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
   const nodes = gltf.nodes
   const materials = gltf.materials
@@ -142,6 +146,7 @@ export function Yaskawa_AR2010({ modelURL, ...props }: RobotModelProps) {
                       rotation={[0, 0, -Math.PI / 2]}
                     />
                     <group
+                      ref={flangeRef}
                       name="YASKAWA_AR2010_FLG"
                       position={[0, -0.1, 0]}
                       rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/Yaskawa_AR2010.tsx
+++ b/src/components/robots/Yaskawa_AR2010.tsx
@@ -21,29 +21,21 @@ export function Yaskawa_AR2010({
         <group name="link_0">
           <mesh
             name="shape"
-            castShadow
-            receiveShadow
             geometry={nodes.shape.geometry}
             material={materials.yaskawa_black}
           />
           <mesh
             name="shape_1"
-            castShadow
-            receiveShadow
             geometry={nodes.shape_1.geometry}
             material={materials.yaskawa_metalsilver}
           />
           <mesh
             name="shape_2"
-            castShadow
-            receiveShadow
             geometry={nodes.shape_2.geometry}
             material={materials.yaskawa_blue}
           />
           <mesh
             name="shape_3"
-            castShadow
-            receiveShadow
             geometry={nodes.shape_3.geometry}
             material={materials.yaskawa_metalsilver}
           />
@@ -52,15 +44,11 @@ export function Yaskawa_AR2010({
           <group name="link_1">
             <mesh
               name="shape001"
-              castShadow
-              receiveShadow
               geometry={nodes.shape001.geometry}
               material={materials.yaskawa_black}
             />
             <mesh
               name="shape001_1"
-              castShadow
-              receiveShadow
               geometry={nodes.shape001_1.geometry}
               material={materials.yaskawa_blue}
             />
@@ -72,8 +60,6 @@ export function Yaskawa_AR2010({
           >
             <mesh
               name="link_2"
-              castShadow
-              receiveShadow
               geometry={nodes.link_2.geometry}
               material={materials.yaskawa_blue}
               position={[0, 0, 0.15]}
@@ -91,15 +77,11 @@ export function Yaskawa_AR2010({
               >
                 <mesh
                   name="shape003"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.shape003.geometry}
                   material={materials.yaskawa_black}
                 />
                 <mesh
                   name="shape003_1"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.shape003_1.geometry}
                   material={materials.yaskawa_blue}
                 />
@@ -111,8 +93,6 @@ export function Yaskawa_AR2010({
               >
                 <mesh
                   name="link_4"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.link_4.geometry}
                   material={materials.yaskawa_blue}
                   position={[-0.96, 0.15, 0]}
@@ -125,8 +105,6 @@ export function Yaskawa_AR2010({
                 >
                   <mesh
                     name="link_5"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.link_5.geometry}
                     material={materials.yaskawa_blue}
                     position={[-0.96, 0, -1.232]}
@@ -138,8 +116,6 @@ export function Yaskawa_AR2010({
                   >
                     <mesh
                       name="link_6"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.link_6.geometry}
                       material={materials.yaskawa_metalsilver}
                       position={[-0.96, 1.232, 0]}

--- a/src/components/robots/Yaskawa_AR3120.tsx
+++ b/src/components/robots/Yaskawa_AR3120.tsx
@@ -7,7 +7,11 @@ Yaskawa_AR3120.config = {
   rotationSign: [1, -1, 1, 1, 1, 1],
 }
 
-export function Yaskawa_AR3120({ modelURL, ...props }: RobotModelProps) {
+export function Yaskawa_AR3120({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
 
   const nodes = gltf.nodes
@@ -43,6 +47,7 @@ export function Yaskawa_AR3120({ modelURL, ...props }: RobotModelProps) {
                       rotation={[-Math.PI / 2, 0, 0]}
                     >
                       <group
+                        ref={flangeRef}
                         name="AR3120_FLG"
                         position={[0, -0.1, 0]}
                         rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/Yaskawa_AR3120.tsx
+++ b/src/components/robots/Yaskawa_AR3120.tsx
@@ -54,8 +54,6 @@ export function Yaskawa_AR3120({
                       />
                       <mesh
                         name="AR3120_L06"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.AR3120_L06.geometry}
                         material={materials["Metal.001"]}
                         rotation={[Math.PI / 2, -Math.PI / 2, 0]}
@@ -63,8 +61,6 @@ export function Yaskawa_AR3120({
                     </animated.group>
                     <mesh
                       name="AR3120_L05"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.AR3120_L05.geometry}
                       material={materials["Blue.001"]}
                       rotation={[Math.PI / 2, 0, Math.PI / 2]}
@@ -76,15 +72,11 @@ export function Yaskawa_AR3120({
                   >
                     <mesh
                       name="R_AXIS_GP20HL001"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.R_AXIS_GP20HL001.geometry}
                       material={materials["Blue.001"]}
                     />
                     <mesh
                       name="R_AXIS_GP20HL001_1"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.R_AXIS_GP20HL001_1.geometry}
                       material={materials["White.001"]}
                     />
@@ -93,15 +85,11 @@ export function Yaskawa_AR3120({
                 <group name="AR3120_L03" rotation={[Math.PI, 0, -Math.PI / 2]}>
                   <mesh
                     name="Mesh_3001"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.Mesh_3001.geometry}
                     material={materials["Blue.001"]}
                   />
                   <mesh
                     name="Mesh_3001_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.Mesh_3001_1.geometry}
                     material={materials["Black.001"]}
                   />
@@ -109,8 +97,6 @@ export function Yaskawa_AR3120({
               </animated.group>
               <mesh
                 name="AR3120_L02"
-                castShadow
-                receiveShadow
                 geometry={nodes.AR3120_L02.geometry}
                 material={materials["Blue.001"]}
                 position={[0, -0.146, 0]}
@@ -124,15 +110,11 @@ export function Yaskawa_AR3120({
             >
               <mesh
                 name="S_AXIS_GP20HL001"
-                castShadow
-                receiveShadow
                 geometry={nodes.S_AXIS_GP20HL001.geometry}
                 material={materials["Blue.001"]}
               />
               <mesh
                 name="S_AXIS_GP20HL001_1"
-                castShadow
-                receiveShadow
                 geometry={nodes.S_AXIS_GP20HL001_1.geometry}
                 material={materials["Black.001"]}
               />
@@ -140,8 +122,6 @@ export function Yaskawa_AR3120({
           </animated.group>
           <mesh
             name="AR3120_L00"
-            castShadow
-            receiveShadow
             geometry={nodes.AR3120_L00.geometry}
             material={materials["Blue.001"]}
             position={[0, -0.54, 0]}

--- a/src/components/robots/Yaskawa_AR900.tsx
+++ b/src/components/robots/Yaskawa_AR900.tsx
@@ -53,56 +53,42 @@ export function Yaskawa_AR900({
                         />
                         <mesh
                           name="AR900_L06"
-                          castShadow
-                          receiveShadow
                           geometry={nodes.AR900_L06.geometry}
                           material={materials["#BBA474.001"]}
                         />
                       </animated.group>
                       <mesh
                         name="AR900_L05"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.AR900_L05.geometry}
                         material={materials["#0056b9.001"]}
                       />
                     </animated.group>
                     <mesh
                       name="AR900_L04"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.AR900_L04.geometry}
                       material={materials["#0056b9.001"]}
                     />
                   </animated.group>
                   <mesh
                     name="AR900_L03"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.AR900_L03.geometry}
                     material={materials["#0056b9.001"]}
                   />
                 </animated.group>
                 <mesh
                   name="AR900_L02"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.AR900_L02.geometry}
                   material={materials["#0056b9.001"]}
                 />
               </animated.group>
               <mesh
                 name="AR900_L01"
-                castShadow
-                receiveShadow
                 geometry={nodes.AR900_L01.geometry}
                 material={materials["#0056b9.001"]}
               />
             </animated.group>
             <mesh
               name="AR900_L00"
-              castShadow
-              receiveShadow
               geometry={nodes.AR900_L00.geometry}
               material={materials["#0056b9.001"]}
               rotation={[-Math.PI / 2, 0, 0]}

--- a/src/components/robots/Yaskawa_AR900.tsx
+++ b/src/components/robots/Yaskawa_AR900.tsx
@@ -6,7 +6,11 @@ Yaskawa_AR900.config = {
   rotationOffsets: [0, -Math.PI / 2, 0, 0, 0, 0],
 }
 
-export function Yaskawa_AR900({ modelURL, ...props }: RobotModelProps) {
+export function Yaskawa_AR900({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
   const nodes = gltf.nodes
   const materials = gltf.materials
@@ -42,6 +46,7 @@ export function Yaskawa_AR900({ modelURL, ...props }: RobotModelProps) {
                         rotation={[-Math.PI / 2, 0, 0]}
                       >
                         <group
+                          ref={flangeRef}
                           name="AR900_FLG"
                           position={[0, -0.08, 0]}
                           rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/Yaskawa_GP50.tsx
+++ b/src/components/robots/Yaskawa_GP50.tsx
@@ -6,7 +6,11 @@ Yaskawa_GP50.config = {
   rotationOffsets: [0, -Math.PI / 2, 0, 0, 0, 0],
 }
 
-export function Yaskawa_GP50({ modelURL, ...props }: RobotModelProps) {
+export function Yaskawa_GP50({
+  modelURL,
+  flangeRef,
+  ...props
+}: RobotModelProps) {
   const gltf = useGLTF(modelURL) as any
 
   const nodes = gltf.nodes
@@ -218,6 +222,7 @@ export function Yaskawa_GP50({ modelURL, ...props }: RobotModelProps) {
                         rotation={[0, 0, -Math.PI / 2]}
                       />
                       <group
+                        ref={flangeRef}
                         name="YASKAWA_GP50_FLG"
                         position={[0, -0.175, 0]}
                         rotation={[-Math.PI, 0, 0]}

--- a/src/components/robots/Yaskawa_GP50.tsx
+++ b/src/components/robots/Yaskawa_GP50.tsx
@@ -23,22 +23,16 @@ export function Yaskawa_GP50({
           <group name="link_0">
             <mesh
               name="shape439"
-              castShadow
-              receiveShadow
               geometry={nodes.shape439.geometry}
               material={materials.yaskawa_blue}
             />
             <mesh
               name="shape439_1"
-              castShadow
-              receiveShadow
               geometry={nodes.shape439_1.geometry}
               material={materials.yaskawa_metalsilver}
             />
             <mesh
               name="shape439_2"
-              castShadow
-              receiveShadow
               geometry={nodes.shape439_2.geometry}
               material={materials.yaskawa_black}
             />
@@ -47,43 +41,31 @@ export function Yaskawa_GP50({
             <group name="link_1" position={[0, 0.54, 0]}>
               <mesh
                 name="shape320"
-                castShadow
-                receiveShadow
                 geometry={nodes.shape320.geometry}
                 material={materials.yaskawa_blue}
               />
               <mesh
                 name="shape320_1"
-                castShadow
-                receiveShadow
                 geometry={nodes.shape320_1.geometry}
                 material={materials.yaskawa_black}
               />
               <mesh
                 name="shape320_2"
-                castShadow
-                receiveShadow
                 geometry={nodes.shape320_2.geometry}
                 material={materials.yaskawa_metalsilver}
               />
               <mesh
                 name="shape320_3"
-                castShadow
-                receiveShadow
                 geometry={nodes.shape320_3.geometry}
                 material={materials.yaskawa_black}
               />
               <mesh
                 name="shape320_4"
-                castShadow
-                receiveShadow
                 geometry={nodes.shape320_4.geometry}
                 material={materials.yaskawa_white}
               />
               <mesh
                 name="shape320_5"
-                castShadow
-                receiveShadow
                 geometry={nodes.shape320_5.geometry}
                 material={materials.yaskawa_black}
               />
@@ -100,29 +82,21 @@ export function Yaskawa_GP50({
               >
                 <mesh
                   name="shape440"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.shape440.geometry}
                   material={materials.yaskawa_blue}
                 />
                 <mesh
                   name="shape440_1"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.shape440_1.geometry}
                   material={materials.yaskawa_white}
                 />
                 <mesh
                   name="shape440_2"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.shape440_2.geometry}
                   material={materials.yaskawa_metalsilver}
                 />
                 <mesh
                   name="shape440_3"
-                  castShadow
-                  receiveShadow
                   geometry={nodes.shape440_3.geometry}
                   material={materials.yaskawa_black}
                 />
@@ -139,43 +113,31 @@ export function Yaskawa_GP50({
                 >
                   <mesh
                     name="shape341"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.shape341.geometry}
                     material={materials.yaskawa_blue}
                   />
                   <mesh
                     name="shape341_1"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.shape341_1.geometry}
                     material={materials.yaskawa_white}
                   />
                   <mesh
                     name="shape341_2"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.shape341_2.geometry}
                     material={materials.yaskawa_black}
                   />
                   <mesh
                     name="shape341_3"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.shape341_3.geometry}
                     material={materials.yaskawa_black}
                   />
                   <mesh
                     name="shape341_4"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.shape341_4.geometry}
                     material={materials.yaskawa_metalsilver}
                   />
                   <mesh
                     name="shape341_5"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.shape341_5.geometry}
                     material={materials.yaskawa_metalsilver}
                   />
@@ -187,8 +149,6 @@ export function Yaskawa_GP50({
                 >
                   <mesh
                     name="link_4"
-                    castShadow
-                    receiveShadow
                     geometry={nodes.link_4.geometry}
                     material={materials.yaskawa_blue}
                     position={[-1.08, 0.145, 0]}
@@ -201,8 +161,6 @@ export function Yaskawa_GP50({
                   >
                     <mesh
                       name="link_5"
-                      castShadow
-                      receiveShadow
                       geometry={nodes.link_5.geometry}
                       material={materials.yaskawa_blue}
                       position={[-1.08, 0, -1.17]}
@@ -214,8 +172,6 @@ export function Yaskawa_GP50({
                     >
                       <mesh
                         name="link_6"
-                        castShadow
-                        receiveShadow
                         geometry={nodes.link_6.geometry}
                         material={materials.yaskawa_metalsilver}
                         position={[-1.08, 1.17, 0]}

--- a/src/components/robots/types.ts
+++ b/src/components/robots/types.ts
@@ -1,7 +1,9 @@
 import type { GroupProps } from "@react-three/fiber"
+import type { Group } from "three"
 
 export type RobotModelProps = {
   modelURL: string
+  flangeRef?: React.MutableRefObject<Group>
 } & GroupProps
 
 /**


### PR DESCRIPTION
This exposes the flange. It's necessary to add the ref to each robot component. Maybe it could also be calculated on the fly, but the suspense handling doesn't make this to easy.