### PR TITLE
feat: add equivalent robots

### DIFF
--- a/src/components/robots/SupportedRobot.tsx
+++ b/src/components/robots/SupportedRobot.tsx
@@ -204,13 +204,25 @@ export const SupportedRobot = externalizeComponent(
       case "Yaskawa_AR1440":
         Robot = Yaskawa_AR1440
         break
+      case "Yaskawa_GP12":
+        Robot = Yaskawa_AR1440
+        break
       case "Yaskawa_AR1730":
+        Robot = Yaskawa_AR1730
+        break
+      case "Yaskawa_GP25":
         Robot = Yaskawa_AR1730
         break
       case "Yaskawa_AR2010":
         Robot = Yaskawa_AR2010
         break
+      case "Yaskawa_GP25_12":
+        Robot = Yaskawa_AR3120
+        break
       case "Yaskawa_AR3120":
+        Robot = Yaskawa_AR3120
+        break
+      case "Yaskawa_GP20HL":
         Robot = Yaskawa_AR3120
         break
       case "Yaskawa_GP50":
@@ -246,10 +258,19 @@ export const SupportedRobot = externalizeComponent(
       case "FANUC_ARC_Mate_120iD":
         Robot = FANUC_ARC_Mate_120iD
         break
+      case "FANUC_M20iD25":
+        Robot = FANUC_ARC_Mate_120iD
+        break
       case "FANUC_ARC_Mate_120iD35":
         Robot = FANUC_ARC_Mate_120iD
         break
+      case "FANUC_M20iD35":
+        Robot = FANUC_ARC_Mate_120iD
+        break
       case "FANUC_ARC_Mate_100iD":
+        Robot = FANUC_ARC_Mate_100iD
+        break
+      case "FANUC_M10iD12":
         Robot = FANUC_ARC_Mate_100iD
         break
       case "KUKA_KR210_R2700":

--- a/stories/robots/FANUC_M10iD12.stories.tsx
+++ b/stories/robots/FANUC_M10iD12.stories.tsx
@@ -6,7 +6,7 @@ import { sharedStoryConfig } from "./robotStoryConfig"
 export default {
   ...sharedStoryConfig,
   tags: ["!autodocs"],
-  title: "3D View/Robot/Supported Models/Yaskawa_GP25",
+  title: "3D View/Robot/Supported Models/FANUC_M10iD12",
 }
 
 function SupportedRobotScene(
@@ -66,8 +66,8 @@ function SupportedRobotScene(
 
 export const RobotStory: StoryObj<typeof SupportedRobotScene> = {
   args: {
-    modelFromController: "Yaskawa_AR1730",
+    modelFromController: "FANUC_ARC_Mate_100iD",
   },
   render: (args) => <SupportedRobotScene {...args} />,
-  name: "Yaskawa_GP25",
+  name: "FANUC_M10iD12",
 }

--- a/stories/robots/FANUC_M20iD25.stories.tsx
+++ b/stories/robots/FANUC_M20iD25.stories.tsx
@@ -1,12 +1,14 @@
 import type { StoryObj } from "@storybook/react"
+import { Euler, Vector3, WebGLRenderer } from "three"
 import { SupportedRobot } from "../../src"
+import type { MotionGroupStateResponse } from "@wandelbots/wandelbots-js"
 import { rapidlyChangingMotionState } from "./motionState"
 import { sharedStoryConfig } from "./robotStoryConfig"
 
 export default {
   ...sharedStoryConfig,
   tags: ["!autodocs"],
-  title: "3D View/Robot/Supported Models/Yaskawa_GP25",
+  title: "3D View/Robot/Supported Models/FANUC_M20iD25",
 }
 
 function SupportedRobotScene(
@@ -66,8 +68,8 @@ function SupportedRobotScene(
 
 export const RobotStory: StoryObj<typeof SupportedRobotScene> = {
   args: {
-    modelFromController: "Yaskawa_AR1730",
+    modelFromController: "FANUC_ARC_Mate_120iD",
   },
   render: (args) => <SupportedRobotScene {...args} />,
-  name: "Yaskawa_GP25",
+  name: "FANUC_M20iD25",
 }

--- a/stories/robots/FANUC_M20iD35.stories.tsx
+++ b/stories/robots/FANUC_M20iD35.stories.tsx
@@ -6,7 +6,7 @@ import { sharedStoryConfig } from "./robotStoryConfig"
 export default {
   ...sharedStoryConfig,
   tags: ["!autodocs"],
-  title: "3D View/Robot/Supported Models/Yaskawa_GP25",
+  title: "3D View/Robot/Supported Models/FANUC_M20iD35",
 }
 
 function SupportedRobotScene(
@@ -66,8 +66,8 @@ function SupportedRobotScene(
 
 export const RobotStory: StoryObj<typeof SupportedRobotScene> = {
   args: {
-    modelFromController: "Yaskawa_AR1730",
+    modelFromController: "FANUC_ARC_Mate_120iD",
   },
   render: (args) => <SupportedRobotScene {...args} />,
-  name: "Yaskawa_GP25",
+  name: "FANUC_M20iD35",
 }

--- a/stories/robots/Yaskawa_GP12.stories.tsx
+++ b/stories/robots/Yaskawa_GP12.stories.tsx
@@ -1,0 +1,73 @@
+import type { StoryObj } from "@storybook/react"
+import { SupportedRobot } from "../../src"
+import { rapidlyChangingMotionState } from "./motionState"
+import { sharedStoryConfig } from "./robotStoryConfig"
+
+export default {
+  ...sharedStoryConfig,
+  tags: ["!autodocs"],
+  title: "3D View/Robot/Supported Models/Yaskawa_GP12",
+}
+
+function SupportedRobotScene(
+  props: React.ComponentProps<typeof SupportedRobot>,
+) {
+  return (
+    <SupportedRobot
+      {...props}
+      rapidlyChangingMotionState={rapidlyChangingMotionState}
+      dhParameters={[
+        {
+          a: 0,
+          d: 89.159000000000006,
+          alpha: 1.5707963267948966,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: -425,
+          d: 0,
+          alpha: 0,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: -392.25,
+          d: 0,
+          alpha: 0,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: 0,
+          d: 109.15000000000001,
+          alpha: 1.5707963267948966,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: 0,
+          d: 94.650000000000006,
+          alpha: -1.5707963267948966,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: 0,
+          d: 82.299999999999997,
+          alpha: 0,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+      ]}
+    />
+  )
+}
+
+export const RobotStory: StoryObj<typeof SupportedRobotScene> = {
+  args: {
+    modelFromController: "Yaskawa_AR1440",
+  },
+  render: (args) => <SupportedRobotScene {...args} />,
+  name: "Yaskawa_GP12",
+}

--- a/stories/robots/Yaskawa_GP20HL.stories.tsx
+++ b/stories/robots/Yaskawa_GP20HL.stories.tsx
@@ -1,0 +1,73 @@
+import type { StoryObj } from "@storybook/react"
+import { SupportedRobot } from "../../src"
+import { rapidlyChangingMotionState } from "./motionState"
+import { sharedStoryConfig } from "./robotStoryConfig"
+
+export default {
+  ...sharedStoryConfig,
+  tags: ["!autodocs"],
+  title: "3D View/Robot/Supported Models/Yaskawa_GP20HL",
+}
+
+function SupportedRobotScene(
+  props: React.ComponentProps<typeof SupportedRobot>,
+) {
+  return (
+    <SupportedRobot
+      {...props}
+      rapidlyChangingMotionState={rapidlyChangingMotionState}
+      dhParameters={[
+        {
+          a: 0,
+          d: 89.159000000000006,
+          alpha: 1.5707963267948966,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: -425,
+          d: 0,
+          alpha: 0,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: -392.25,
+          d: 0,
+          alpha: 0,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: 0,
+          d: 109.15000000000001,
+          alpha: 1.5707963267948966,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: 0,
+          d: 94.650000000000006,
+          alpha: -1.5707963267948966,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: 0,
+          d: 82.299999999999997,
+          alpha: 0,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+      ]}
+    />
+  )
+}
+
+export const RobotStory: StoryObj<typeof SupportedRobotScene> = {
+  args: {
+    modelFromController: "Yaskawa_AR3120",
+  },
+  render: (args) => <SupportedRobotScene {...args} />,
+  name: "Yaskawa_GP20HL",
+}

--- a/stories/robots/Yaskawa_GP25.stories.tsx
+++ b/stories/robots/Yaskawa_GP25.stories.tsx
@@ -1,0 +1,75 @@
+import type { StoryObj } from "@storybook/react"
+import { Euler, Vector3, WebGLRenderer } from "three"
+import { SupportedRobot } from "../../src"
+import type { MotionGroupStateResponse } from "@wandelbots/wandelbots-js"
+import { rapidlyChangingMotionState } from "./motionState"
+import { sharedStoryConfig } from "./robotStoryConfig"
+
+export default {
+  ...sharedStoryConfig,
+  tags: ["!autodocs"],
+  title: "3D View/Robot/Supported Models/Yaskawa_GP25",
+}
+
+function SupportedRobotScene(
+  props: React.ComponentProps<typeof SupportedRobot>,
+) {
+  return (
+    <SupportedRobot
+      {...props}
+      rapidlyChangingMotionState={rapidlyChangingMotionState}
+      dhParameters={[
+        {
+          a: 0,
+          d: 89.159000000000006,
+          alpha: 1.5707963267948966,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: -425,
+          d: 0,
+          alpha: 0,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: -392.25,
+          d: 0,
+          alpha: 0,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: 0,
+          d: 109.15000000000001,
+          alpha: 1.5707963267948966,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: 0,
+          d: 94.650000000000006,
+          alpha: -1.5707963267948966,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: 0,
+          d: 82.299999999999997,
+          alpha: 0,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+      ]}
+    />
+  )
+}
+
+export const RobotStory: StoryObj<typeof SupportedRobotScene> = {
+  args: {
+    modelFromController: "Yaskawa_GP25",
+  },
+  render: (args) => <SupportedRobotScene {...args} />,
+  name: "Yaskawa_GP25",
+}

--- a/stories/robots/Yaskawa_GP25_12.stories.tsx
+++ b/stories/robots/Yaskawa_GP25_12.stories.tsx
@@ -1,0 +1,73 @@
+import type { StoryObj } from "@storybook/react"
+import { SupportedRobot } from "../../src"
+import { rapidlyChangingMotionState } from "./motionState"
+import { sharedStoryConfig } from "./robotStoryConfig"
+
+export default {
+  ...sharedStoryConfig,
+  tags: ["!autodocs"],
+  title: "3D View/Robot/Supported Models/Yaskawa_GP25_12",
+}
+
+function SupportedRobotScene(
+  props: React.ComponentProps<typeof SupportedRobot>,
+) {
+  return (
+    <SupportedRobot
+      {...props}
+      rapidlyChangingMotionState={rapidlyChangingMotionState}
+      dhParameters={[
+        {
+          a: 150,
+          d: 0,
+          alpha: -1.5707963267948966,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: 760,
+          d: 0,
+          alpha: 3.1415926535897931,
+          theta: -1.5707963267948966,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: 200,
+          d: 0,
+          alpha: -1.5707963267948966,
+          theta: 3.1415926535897931,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: 0,
+          d: -1082,
+          alpha: 1.5707963267948966,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: 0,
+          d: 0,
+          alpha: -1.5707963267948966,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+        {
+          a: 0,
+          d: -100,
+          alpha: 3.1415926535897931,
+          theta: 0,
+          reverse_rotation_direction: false,
+        },
+      ]}
+    />
+  )
+}
+
+export const RobotStory: StoryObj<typeof SupportedRobotScene> = {
+  args: {
+    modelFromController: "Yaskawa_AR2010",
+  },
+  render: (args) => <SupportedRobotScene {...args} />,
+  name: "Yaskawa_GP25_12",
+}


### PR DESCRIPTION
{ Yaskawa_GP12,      Yaskawa_AR1440 },
{ Yaskawa_GP25,      Yaskawa_AR1730 },
{ Yaskawa_GP25_12,   Yaskawa_AR2010 },
{ Yaskawa_GP20HL,    Yaskawa_AR3120 },
{ Yaskawa_GP8,       Yaskawa_AR700 },
{ Yaskawa_GP7,       Yaskawa_AR900 },

 { FANUC_ARC_Mate_100iD,   FANUC_M10iD12 },
 { FANUC_ARC_Mate_120iD,   FANUC_M20iD25 },
 { FANUC_ARC_Mate_120iD35, FANUC_M20iD35 }