### PR TITLE
feat(RPS-52): Add syntax highlighting for `and`, `or` and `not` keywords

### DIFF
--- a/src/components/wandelscript-editor/wandelscript.tmLanguage.ts
+++ b/src/components/wandelscript-editor/wandelscript.tmLanguage.ts
@@ -22,7 +22,7 @@ export default {
         {
           name: "keyword.control.flow.wandelscript",
           match:
-            "\\b(move|via|to|interrupt|def|False|True|for|if|else|elif|while|return|switch|activate|deactivate|print)\\b",
+            "\\b(move|via|to|interrupt|def|False|True|for|if|else|elif|while|return|switch|activate|deactivate|print|and|or|not)\\b",
         },
       ],
     },


### PR DESCRIPTION
Add syntax highlighting for Wandelscript keywords `and`, `or` and `not` in the robot pad.