### PR TITLE
fix: Increment rotation jogging now correctly uses rads instead of degs

### DIFF
--- a/src/components/jogging/JoggingCartesianTab.tsx
+++ b/src/components/jogging/JoggingCartesianTab.tsx
@@ -83,7 +83,10 @@ export const JoggingCartesianTab = observer(
             currentTcpPose: tcpPose,
             currentJoints: jointPosition,
             coordSystemId: store.activeCoordSystemId,
-            velocityInRelevantUnits: store.velocityInCurrentUnits,
+            velocityInRelevantUnits:
+              store.selectedCartesianMotionType === "translate"
+                ? store.translationVelocityMmPerSec
+                : store.rotationVelocityRadsPerSec,
             axis: opts.axis,
             direction: opts.direction,
             motion:

--- a/src/components/jogging/JoggingStore.ts
+++ b/src/components/jogging/JoggingStore.ts
@@ -340,19 +340,22 @@ export class JoggingStore {
     return (this.rotationVelocityDegPerSec * Math.PI) / 180
   }
 
-  get velocityInCurrentUnits() {
+  /** Selected velocity in mm/sec or deg/sec */
+  get velocityInDisplayUnits() {
     return this.currentMotionType === "translate"
       ? this.translationVelocityMmPerSec
       : this.rotationVelocityDegPerSec
   }
 
-  get minVelocityInCurrentUnits() {
+  /** Minimum selectable velocity in mm/sec or deg/sec */
+  get minVelocityInDisplayUnits() {
     return this.currentMotionType === "translate"
       ? this.minTranslationVelocityMmPerSec
       : this.minRotationVelocityDegPerSec
   }
 
-  get maxVelocityInCurrentUnits() {
+  /** Maximum selectable velocity in mm/sec or deg/sec */
+  get maxVelocityInDisplayUnits() {
     return this.currentMotionType === "translate"
       ? this.maxTranslationVelocityMmPerSec
       : this.maxRotationVelocityDegPerSec

--- a/src/components/jogging/JoggingVelocitySlider.tsx
+++ b/src/components/jogging/JoggingVelocitySlider.tsx
@@ -21,9 +21,9 @@ export const JoggingVelocitySlider = observer(
 
     return (
       <VelocitySlider
-        velocity={store.velocityInCurrentUnits}
-        min={store.minVelocityInCurrentUnits}
-        max={store.maxVelocityInCurrentUnits}
+        velocity={store.velocityInDisplayUnits}
+        min={store.minVelocityInDisplayUnits}
+        max={store.maxVelocityInDisplayUnits}
         onVelocityChange={store.setVelocityFromSlider}
         disabled={store.isLocked}
         renderValue={(value) => (


### PR DESCRIPTION
[Storybook Link](https://wandelbotsgmbh.github.io/wandelbots-js-react-components/overview.html)
