### PR TITLE
fix: Joint jogging now properly closes websocket after use

### DIFF
--- a/src/components/jogging/JoggingJointTab.tsx
+++ b/src/components/jogging/JoggingJointTab.tsx
@@ -24,6 +24,7 @@ export const JoggingJointTab = observer(
 
     async function stopJointJogging() {
       await store.jogger.stop()
+      await store.deactivate()
     }
 
     return (


### PR DESCRIPTION
Need to rework the jogger in wbjs at some point, but this will do for now