### PR TITLE
fix: More permissive fallback model loading

### DIFF
--- a/src/components/robots/SupportedRobot.tsx
+++ b/src/components/robots/SupportedRobot.tsx
@@ -69,12 +69,8 @@ export const SupportedRobot = externalizeComponent(
       <ErrorBoundary
         fallback={dhrobot}
         onError={(err) => {
-          if (err.message.includes("404: Not Found")) {
-            // Missing model; show the fallback for now
-            console.error(err)
-          } else {
-            throw err
-          }
+          // Missing model; show the fallback for now
+          console.error(err)
         }}
       >
         <Suspense fallback={dhrobot}>


### PR DESCRIPTION
[Storybook Link](https://wandelbotsgmbh.github.io/wandelbots-js-react-components/overview.html)

I think the error message changed with one of the dependency updates and broke the boundary check; since we can't detect handleable model load errors reliably let's just always fallback for now