### PR TITLE
fix: performance issues

### DIFF
--- a/etc/api-extractor/core.api.md
+++ b/etc/api-extractor/core.api.md
@@ -243,10 +243,6 @@ export class JoggerConnection {
     // (undocumented)
     dispose(): Promise<void[]>;
     // (undocumented)
-    ENDPOINT_JOGGING: string;
-    // (undocumented)
-    ENDPOINT_TRAJECTORY: string;
-    // (undocumented)
     getDefaultTcp(motionStream: MotionStreamConnection): string | undefined;
     // (undocumented)
     initializeJoggingWebsocket(): Promise<void>;

--- a/etc/api-extractor/index.api.md
+++ b/etc/api-extractor/index.api.md
@@ -312,10 +312,6 @@ export class JoggerConnection {
     // (undocumented)
     dispose(): Promise<void[]>;
     // (undocumented)
-    ENDPOINT_JOGGING: string;
-    // (undocumented)
-    ENDPOINT_TRAJECTORY: string;
-    // (undocumented)
     getDefaultTcp(motionStream: MotionStreamConnection): string | undefined;
     // (undocumented)
     initializeJoggingWebsocket(): Promise<void>;

--- a/src/components/3d-viewport/PresetEnvironment.tsx
+++ b/src/components/3d-viewport/PresetEnvironment.tsx
@@ -7,13 +7,15 @@ import { Environment, Lightformer } from "@react-three/drei"
  */
 export function PresetEnvironment() {
   return (
-    <Environment>
+    <Environment frames={1}>
       <Lightformers />
     </Environment>
   )
 }
 
-function Lightformers({ positions = [2, 0, 2, 0, 2, 0, 2, 0] }) {
+const defaultPositions = [2, 0, 2, 0, 2, 0, 2, 0]
+
+function Lightformers({ positions = defaultPositions }) {
   return (
     <>
       {/* Ceiling */}

--- a/src/components/3d-viewport/SafetyZonesRenderer.tsx
+++ b/src/components/3d-viewport/SafetyZonesRenderer.tsx
@@ -19,6 +19,19 @@ import {
   verticesToCoplanarity,
 } from "../utils/converters"
 
+/**
+ * Common material properties for safety zone meshes
+ */
+const safetyZoneMaterialProps = {
+  attach: "material" as const,
+  color: "#009f4d",
+  opacity: 0.2,
+  depthTest: false,
+  depthWrite: false,
+  transparent: true,
+  polygonOffset: true,
+}
+
 export type SafetyZonesRendererProps = {
   safetyZones: MotionGroupDescription["safety_zones"]
   dhParameters?: DHParameter[]
@@ -30,23 +43,13 @@ export function SafetyZonesRenderer({
   ...props
 }: SafetyZonesRendererProps) {
   /**
-   * Common material properties for safety zone meshes
-   */
-  const safetyZoneMaterialProps = {
-    attach: "material" as const,
-    color: "#009f4d",
-    opacity: 0.2,
-    depthTest: false,
-    depthWrite: false,
-    transparent: true,
-    polygonOffset: true,
-  }
-
-  /**
    * Plane size for the plane safety zones, returns the reach distance
    * of the robot
    */
-  const planeSize = dhParametersToPlaneSize(dhParameters ?? [])
+  const planeSize = useMemo(
+    () => dhParametersToPlaneSize(dhParameters ?? []),
+    [dhParameters],
+  )
 
   /**
    * Helper function to render plane, sphere, and capsule meshes

--- a/src/components/robots/GenericRobot.tsx
+++ b/src/components/robots/GenericRobot.tsx
@@ -103,13 +103,12 @@ export function GenericRobot({
   const [resolvedURL, setResolvedURL] = useState<string | null>(null)
 
   useEffect(() => {
+    let cancelled = false
     const resolveURL = async () => {
       try {
-        if (typeof modelURL === "string") {
-          setResolvedURL(modelURL)
-        } else {
-          const url = await modelURL
-          setResolvedURL(url)
+        const url = typeof modelURL === "string" ? modelURL : await modelURL
+        if (!cancelled) {
+          setResolvedURL((prev: string | null) => (prev === url ? prev : url))
         }
       } catch (error) {
         console.error("Failed to resolve model URL:", error)
@@ -117,6 +116,9 @@ export function GenericRobot({
     }
 
     resolveURL()
+    return () => {
+      cancelled = true
+    }
   }, [modelURL])
 
   // Don't render until we have a resolved URL

--- a/src/components/robots/RobotAnimator.tsx
+++ b/src/components/robots/RobotAnimator.tsx
@@ -106,7 +106,7 @@ export default function RobotAnimator({
    * Calling setTarget with the same values is idempotent and cheap.
    */
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  // biome-ignore lint/correctness/useExhaustiveDependencies: false positive
   useEffect(() => {
     applyMotionState(rapidlyChangingMotionState)
   }, [rapidlyChangingMotionState])

--- a/src/components/robots/RobotAnimator.tsx
+++ b/src/components/robots/RobotAnimator.tsx
@@ -105,6 +105,8 @@ export default function RobotAnimator({
    * Plain-prop path: catch reference changes not tracked by MobX.
    * Calling setTarget with the same values is idempotent and cheap.
    */
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     applyMotionState(rapidlyChangingMotionState)
   }, [rapidlyChangingMotionState])

--- a/src/components/robots/RobotAnimator.tsx
+++ b/src/components/robots/RobotAnimator.tsx
@@ -1,7 +1,7 @@
 import { useFrame, useThree } from "@react-three/fiber"
 import type { DHParameter, MotionGroupState } from "@wandelbots/nova-js/v2"
 import type React from "react"
-import { useCallback, useEffect, useRef } from "react"
+import { useEffect, useRef } from "react"
 import type { Group, Object3D } from "three"
 import { useAutorun } from "../utils/hooks"
 import { ValueInterpolator } from "../utils/interpolation"
@@ -20,10 +20,11 @@ export default function RobotAnimator({
   onRotationChanged,
   children,
 }: RobotAnimatorProps) {
-  const jointValues = useRef<number[]>([])
   const jointObjects = useRef<Object3D[]>([])
   const interpolatorRef = useRef<ValueInterpolator | null>(null)
   const { invalidate } = useThree()
+  const motionStateRef = useRef(rapidlyChangingMotionState)
+  motionStateRef.current = rapidlyChangingMotionState
 
   // Initialize interpolator
   // biome-ignore lint/correctness/useExhaustiveDependencies: pre-biome code
@@ -83,34 +84,30 @@ export default function RobotAnimator({
     }
   }
 
-  const updateJoints = useCallback(() => {
-    const newJointValues = rapidlyChangingMotionState.joint_position.filter(
+  // Single path for feeding new joint targets — works for both MobX and plain props
+  function applyMotionState(state: MotionGroupState) {
+    const newJointValues = state.joint_position.filter(
       (item) => item !== undefined,
     )
-
-    requestAnimationFrame(() => {
-      jointValues.current = newJointValues
-      interpolatorRef.current?.setTarget(newJointValues)
-    })
-  }, [rapidlyChangingMotionState])
+    interpolatorRef.current?.setTarget(newJointValues)
+    invalidate()
+  }
 
   /**
-   * Fire an update joints call on every motion state change.
-   * requestAnimationFrame used to avoid blocking main thread
-   */
-  // biome-ignore lint/correctness/useExhaustiveDependencies: pre-biome code
-  useEffect(() => {
-    updateJoints()
-  }, [rapidlyChangingMotionState, updateJoints])
-
-  /**
-   * As some consumer applications (eg. storybook) deliver
-   * mobx observable for rapidlyChangingMotionState, we need to
-   * register the watcher to get the newest value updates
+   * MobX path: autorun tracks observable reads inside the callback.
+   * Reads motionStateRef.current which dereferences the observable's properties.
    */
   useAutorun(() => {
-    updateJoints()
+    applyMotionState(motionStateRef.current)
   })
+
+  /**
+   * Plain-prop path: catch reference changes not tracked by MobX.
+   * Calling setTarget with the same values is idempotent and cheap.
+   */
+  useEffect(() => {
+    applyMotionState(rapidlyChangingMotionState)
+  }, [rapidlyChangingMotionState])
 
   return <group ref={setGroupRef}>{children}</group>
 }

--- a/src/components/robots/SupportedRobot.tsx
+++ b/src/components/robots/SupportedRobot.tsx
@@ -1,6 +1,6 @@
 import type { ThreeElements } from "@react-three/fiber"
 import type { DHParameter, MotionGroupState } from "@wandelbots/nova-js/v2"
-import { Suspense, useCallback, useEffect, useState } from "react"
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react"
 import { DHRobot } from "./DHRobot"
 
 import { ErrorBoundary } from "react-error-boundary"
@@ -59,6 +59,20 @@ export const SupportedRobot = externalizeComponent(
       }
     }, [robotGroup, transparentColor])
 
+    const modelURL = useMemo(() => {
+      const result = getModel(modelFromController, instanceUrl)
+      if (!result) {
+        const mockBlob = new Blob([], { type: "model/gltf-binary" })
+        const mockFile = new File(
+          [mockBlob],
+          `${modelFromController}.glb`,
+          { type: "model/gltf-binary" },
+        )
+        return Promise.resolve(URL.createObjectURL(mockFile))
+      }
+      return result
+    }, [modelFromController, instanceUrl, getModel])
+
     const dhrobot = (
       <DHRobot
         rapidlyChangingMotionState={rapidlyChangingMotionState}
@@ -82,19 +96,7 @@ export const SupportedRobot = externalizeComponent(
               dhParameters={dhParameters}
             >
               <GenericRobot
-                modelURL={(() => {
-                  const result = getModel(modelFromController, instanceUrl)
-                  if (!result) {
-                    const mockBlob = new Blob([], { type: "model/gltf-binary" })
-                    const mockFile = new File(
-                      [mockBlob],
-                      `${modelFromController}.glb`,
-                      { type: "model/gltf-binary" },
-                    )
-                    return Promise.resolve(URL.createObjectURL(mockFile))
-                  }
-                  return result
-                })()}
+                modelURL={modelURL}
                 postModelRender={postModelRender}
                 flangeRef={flangeRef}
                 {...props}

--- a/src/components/robots/SupportedRobot.tsx
+++ b/src/components/robots/SupportedRobot.tsx
@@ -63,11 +63,9 @@ export const SupportedRobot = externalizeComponent(
       const result = getModel(modelFromController, instanceUrl)
       if (!result) {
         const mockBlob = new Blob([], { type: "model/gltf-binary" })
-        const mockFile = new File(
-          [mockBlob],
-          `${modelFromController}.glb`,
-          { type: "model/gltf-binary" },
-        )
+        const mockFile = new File([mockBlob], `${modelFromController}.glb`, {
+          type: "model/gltf-binary",
+        })
         return Promise.resolve(URL.createObjectURL(mockFile))
       }
       return result

--- a/src/components/robots/SupportedRobot.tsx
+++ b/src/components/robots/SupportedRobot.tsx
@@ -62,11 +62,9 @@ export const SupportedRobot = externalizeComponent(
     const modelURL = useMemo(() => {
       const result = getModel(modelFromController, instanceUrl)
       if (!result) {
-        const mockBlob = new Blob([], { type: "model/gltf-binary" })
-        const mockFile = new File([mockBlob], `${modelFromController}.glb`, {
-          type: "model/gltf-binary",
-        })
-        return Promise.resolve(URL.createObjectURL(mockFile))
+        throw new Error(
+          `No model found for robot "${modelFromController}". Ensure the model is available or provide a custom getModel function.`,
+        )
       }
       return result
     }, [modelFromController, instanceUrl, getModel])

--- a/src/externalizeComponent.tsx
+++ b/src/externalizeComponent.tsx
@@ -1,6 +1,6 @@
 /* biome-ignore-all lint/suspicious/noExplicitAny: pre-biome code */
 
-import type { FC } from "react"
+import { type FC, memo } from "react"
 import { I18nextProvider } from "react-i18next"
 import { i18n } from "./i18n/config"
 
@@ -12,9 +12,11 @@ import { i18n } from "./i18n/config"
 export function externalizeComponent<T extends React.JSX.ElementType>(
   Component: T,
 ): T {
-  const WrappedComponent = ((props: T) => (
+  const MemoizedComponent = memo(Component as any)
+
+  const WrappedComponent = ((props: any) => (
     <NovaComponentsProvider>
-      <Component {...(props as any)} />
+      <MemoizedComponent {...props} />
     </NovaComponentsProvider>
   )) as any
 

--- a/src/lib/JoggerConnection.ts
+++ b/src/lib/JoggerConnection.ts
@@ -53,8 +53,6 @@ export type JoggerMode = "jogging" | "trajectory" | "off"
 export type JoggerOrientation = "coordsys" | "tool"
 
 export class JoggerConnection {
-  ENDPOINT_JOGGING = "/execution/jogging"
-  ENDPOINT_TRAJECTORY = "/execution/trajectory"
   DEFAULT_MODE = "off" as JoggerMode
   DEFAULT_TCP: string | undefined = "Flange"
   NO_TCP: string | undefined = undefined
@@ -257,7 +255,7 @@ export class JoggerConnection {
       }, this.timeout)
 
       this.joggingSocket = this.nova.openReconnectingWebsocket(
-        this.ENDPOINT_JOGGING,
+        `/controllers/${this.motionStream.controllerId}/execution/jogging`,
       )
       this.joggingSocket.addEventListener("message", (ev: MessageEvent) => {
         const data = tryParseJson(ev.data)
@@ -564,7 +562,7 @@ export class JoggerConnection {
 
     // Execute the planned motion https://portal.wandelbots.io/docs/api/v2/ui/#/operations/executeTrajectory
     this.trajectorySocket = this.nova.openReconnectingWebsocket(
-      this.ENDPOINT_TRAJECTORY,
+      `/controllers/${this.motionStream.controllerId}/execution/trajectory`,
     )
 
     const messageInitializeMovementResponse = (


### PR DESCRIPTION
### Performance: 

Reduce unnecessary React re-renders and WebGL work at high motion state update rates
Fixes several sources of redundant work triggered at NATS WebSocket message rates (30–100 Hz) in the 3D robot visualization pipeline.
### Changes

- RobotAnimator: Removed redundant useCallback/useEffect pair and the requestAnimationFrame wrapper around setTarget. Joint targets are now set synchronously via a shared applyMotionState function called by both the MobX useAutorun path and the plain-prop useEffect path.
- SupportedRobot: Wrapped modelURL computation in useMemo — previously a new Blob, File, and URL.createObjectURL were allocated on every render.
- GenericRobot: URL resolution now uses a cancellation flag and a functional state setter that skips updates when the resolved URL hasn't changed.
- externalizeComponent: Wrapped the inner component with React.memo to prevent re-renders from unrelated parent state changes.
- SafetyZonesRenderer: Moved safetyZoneMaterialProps to module scope and wrapped planeSize in useMemo, making the renderedSafetyZones memo actually effective.
- PresetEnvironment: Added frames={1} to <Environment> so the cubemap is rendered only once. Hoisted the defaultPositions array to module scope.