### PR TITLE
fix: allow-jogging-around-tcp-coordinates

### DIFF
--- a/src/lib/JoggerConnection.ts
+++ b/src/lib/JoggerConnection.ts
@@ -380,6 +380,7 @@ export class JoggerConnection {
       message_type: "TcpVelocityRequest",
       translation,
       rotation,
+      use_tool_coordinate_system: this.orientation === "tool",
     })
   }
 


### PR DESCRIPTION
fix missing jogging around tcp