### PR TITLE
Fix typo in JoggerConnection docs

### DIFF
--- a/stories/JoggerConnection.mdx
+++ b/stories/JoggerConnection.mdx
@@ -22,7 +22,7 @@ This connected motion group opens a websocket and listens to changes of the curr
 const newJoints = activeRobot.rapidlyChangingMotionState.joint_position
 ```
 
-**Api V2 change:** Please not that joints are now directly accessible in `rapidlyChangingMotionState.joint_position`, previously there were nested in `.rapidlyChangingMotionState.state.joint_position.joints`.
+**Api V2 change:** Please note that joints are now directly accessible in `rapidlyChangingMotionState.joint_position`, previously there were nested in `.rapidlyChangingMotionState.state.joint_position.joints`.
 
 ## JoggerConnection
 


### PR DESCRIPTION
Fixes a small typo in the JoggerConnection Storybook documentation:

- "Please not that" -> "Please note that"