### PR TITLE
feat: Make robot joint interpolation strategy pluggable

### DIFF
--- a/etc/api-extractor/3d.api.md
+++ b/etc/api-extractor/3d.api.md
@@ -55,6 +55,15 @@ export function extractManufacturer(modelFromController: string): Manufacturer |
 export function getDefaultHomeConfig(modelFromController: string, defaultJointConfig?: number[]): number[] | null;
 
 // @public
+export interface InterpolationOptions {
+    friction?: number;
+    onChange?: (values: number[]) => void;
+    onComplete?: (values: number[]) => void;
+    tension?: number;
+    threshold?: number;
+}
+
+// @public
 export function LinearAxis(input: LinearAxisProps): JSX.Element | null;
 
 // @public (undocumented)
@@ -77,6 +86,17 @@ export type MotionGroupVisualizerProps = {
     instanceUrl: string;
     inverseSolver?: string | null;
 } & (SupportedRobotProps | SupportedLinearAxisProps);
+
+// @public
+export interface MotionInterpolator {
+    destroy?(): void;
+    getCurrentValues(): number[];
+    setTarget(values: number[]): void;
+    update(delta: number): boolean;
+}
+
+// @public
+export type MotionInterpolatorFactory = (initialValues: number[]) => MotionInterpolator;
 
 // @public
 export function PresetEnvironment(): JSX.Element;
@@ -144,6 +164,7 @@ export type SupportedLinearAxisProps = {
     getModel?: (modelFromController: string, instanceUrl?: string) => Promise<string> | undefined;
     postModelRender?: () => void;
     transparentColor?: string;
+    createInterpolator?: MotionInterpolatorFactory;
 } & ThreeElements["group"];
 
 // @public (undocumented)
@@ -159,6 +180,7 @@ export type SupportedRobotProps = {
     getModel?: (modelFromController: string, instanceUrl?: string) => Promise<string> | undefined;
     postModelRender?: () => void;
     transparentColor?: string;
+    createInterpolator?: MotionInterpolatorFactory;
 } & ThreeElements["group"];
 
 // @public (undocumented)
@@ -168,6 +190,24 @@ export function TrajectoryRenderer(input: TrajectoryRendererProps): JSX.Element;
 export type TrajectoryRendererProps = {
     trajectory: Pose[];
 } & React.JSX.IntrinsicElements["group"];
+
+// @public
+export function useInterpolation(initialValues?: number[], options?: InterpolationOptions): [ValueInterpolator];
+
+// @public (undocumented)
+export class ValueInterpolator implements MotionInterpolator {
+    constructor(initialValues?: number[], options?: InterpolationOptions);
+    destroy(): void;
+    getCurrentValues(): number[];
+    getValue(index: number): number;
+    isInterpolating(): boolean;
+    setImmediate(values: number[]): void;
+    setTarget(newValues: number[]): void;
+    startAutoInterpolation(): void;
+    stop(): void;
+    update(delta?: number): boolean;
+    updateOptions(newOptions: Partial<InterpolationOptions>): void;
+}
 
 // (No @packageDocumentation comment for this package)
 

--- a/etc/api-extractor/core.api.md
+++ b/etc/api-extractor/core.api.md
@@ -599,6 +599,17 @@ export type MotionGroupOption = {
     selectionId: string;
 };
 
+// @public
+export interface MotionInterpolator {
+    destroy?(): void;
+    getCurrentValues(): number[];
+    setTarget(values: number[]): void;
+    update(delta: number): boolean;
+}
+
+// @public
+export type MotionInterpolatorFactory = (initialValues: number[]) => MotionInterpolator;
+
 // @public (undocumented)
 export class MotionStreamConnection {
     constructor(nova: AnyNovaClient, controller: RobotControllerState, motionGroup: MotionGroupState, description: MotionGroupDescription, initialMotionState: MotionGroupState, motionStateSocket: AutoReconnectingWebsocket, cellId?: string);
@@ -876,7 +887,7 @@ export function useMounted(effect: EffectCallback): void;
 export function useReaction<T>(expression: Parameters<typeof reaction<T>>[0], effect: Parameters<typeof reaction<T>>[1], opts?: Parameters<typeof reaction<T>>[2]): void;
 
 // @public (undocumented)
-export class ValueInterpolator {
+export class ValueInterpolator implements MotionInterpolator {
     constructor(initialValues?: number[], options?: InterpolationOptions);
     destroy(): void;
     getCurrentValues(): number[];

--- a/etc/api-extractor/index.api.md
+++ b/etc/api-extractor/index.api.md
@@ -658,6 +658,17 @@ export type MotionGroupVisualizerProps = {
     inverseSolver?: string | null;
 } & (SupportedRobotProps | SupportedLinearAxisProps);
 
+// @public
+export interface MotionInterpolator {
+    destroy?(): void;
+    getCurrentValues(): number[];
+    setTarget(values: number[]): void;
+    update(delta: number): boolean;
+}
+
+// @public
+export type MotionInterpolatorFactory = (initialValues: number[]) => MotionInterpolator;
+
 // @public (undocumented)
 export class MotionStreamConnection {
     constructor(nova: AnyNovaClient, controller: RobotControllerState, motionGroup: MotionGroupState, description: MotionGroupDescription, initialMotionState: MotionGroupState, motionStateSocket: AutoReconnectingWebsocket, cellId?: string);
@@ -921,6 +932,7 @@ export type SupportedLinearAxisProps = {
     getModel?: (modelFromController: string, instanceUrl?: string) => Promise<string> | undefined;
     postModelRender?: () => void;
     transparentColor?: string;
+    createInterpolator?: MotionInterpolatorFactory;
 } & ThreeElements["group"];
 
 // @public (undocumented)
@@ -936,6 +948,7 @@ export type SupportedRobotProps = {
     getModel?: (modelFromController: string, instanceUrl?: string) => Promise<string> | undefined;
     postModelRender?: () => void;
     transparentColor?: string;
+    createInterpolator?: MotionInterpolatorFactory;
 } & ThreeElements["group"];
 
 // @public
@@ -1026,7 +1039,7 @@ export function useMounted(effect: EffectCallback): void;
 export function useReaction<T>(expression: Parameters<typeof reaction<T>>[0], effect: Parameters<typeof reaction<T>>[1], opts?: Parameters<typeof reaction<T>>[2]): void;
 
 // @public (undocumented)
-export class ValueInterpolator {
+export class ValueInterpolator implements MotionInterpolator {
     constructor(initialValues?: number[], options?: InterpolationOptions);
     destroy(): void;
     getCurrentValues(): number[];

--- a/src/3d.ts
+++ b/src/3d.ts
@@ -16,3 +16,6 @@ export { defaultGetModel } from "./components/robots/robotModelLogic"
 export * from "./components/robots/SupportedLinearAxis"
 export * from "./components/robots/SupportedRobot"
 export * from "./components/robots/MotionGroupVisualizer"
+// Interpolation strategy types/classes referenced by the robot component props,
+// so the 3d entry point is self-contained for consumers customizing smoothing.
+export * from "./components/utils/interpolation"

--- a/src/components/robots/LinearAxisAnimator.tsx
+++ b/src/components/robots/LinearAxisAnimator.tsx
@@ -4,26 +4,44 @@ import type React from "react"
 import { useCallback, useEffect, useRef } from "react"
 import type { Group, Object3D } from "three"
 import { useAutorun } from "../utils/hooks"
-import { ValueInterpolator } from "../utils/interpolation"
+import {
+  type MotionInterpolator,
+  type MotionInterpolatorFactory,
+  ValueInterpolator,
+} from "../utils/interpolation"
 import { collectJoints } from "./robotModelLogic"
 
 type LinearAxisAnimatorProps = {
   rapidlyChangingMotionState: MotionGroupState
   dhParameters: DHParameter[]
   onTranslationChanged?: (joints: Object3D[], jointValues: number[]) => void
+  /**
+   * Strategy used to interpolate joint values towards each incoming motion
+   * state. Defaults to spring smoothing via {@link ValueInterpolator}. Provide a
+   * custom {@link MotionInterpolatorFactory} to tune the spring, follow the
+   * streamed pose exactly (no smoothing), or plug in any other behaviour.
+   */
+  createInterpolator?: MotionInterpolatorFactory
   children: React.ReactNode
 }
+
+const defaultCreateInterpolator: MotionInterpolatorFactory = (initialValues) =>
+  new ValueInterpolator(initialValues)
 
 export default function LinearAxisAnimator({
   rapidlyChangingMotionState,
   dhParameters,
   onTranslationChanged,
+  createInterpolator = defaultCreateInterpolator,
   children,
 }: LinearAxisAnimatorProps) {
   const jointValues = useRef<number[]>([])
   const jointObjects = useRef<Object3D[]>([])
-  const interpolatorRef = useRef<ValueInterpolator | null>(null)
+  const interpolatorRef = useRef<MotionInterpolator | null>(null)
   const { invalidate } = useThree()
+
+  // Read the factory once on mount (see MotionInterpolatorFactory docs).
+  const createInterpolatorRef = useRef(createInterpolator)
 
   // Initialize interpolator
   // biome-ignore lint/correctness/useExhaustiveDependencies: pre-biome code
@@ -32,14 +50,10 @@ export default function LinearAxisAnimator({
       (item) => item !== undefined,
     )
 
-    interpolatorRef.current = new ValueInterpolator(initialJointValues, {
-      tension: 120, // Controls spring stiffness - higher values create faster, more responsive motion
-      friction: 20, // Controls damping - higher values reduce oscillation and create smoother settling
-      threshold: 0.001,
-    })
+    interpolatorRef.current = createInterpolatorRef.current(initialJointValues)
 
     return () => {
-      interpolatorRef.current?.destroy()
+      interpolatorRef.current?.destroy?.()
     }
   }, [])
 

--- a/src/components/robots/RobotAnimator.tsx
+++ b/src/components/robots/RobotAnimator.tsx
@@ -4,7 +4,11 @@ import type React from "react"
 import { forwardRef, useEffect, useImperativeHandle, useRef } from "react"
 import type { Group, Object3D } from "three"
 import { useAutorun } from "../utils/hooks"
-import { ValueInterpolator } from "../utils/interpolation"
+import {
+  type MotionInterpolator,
+  type MotionInterpolatorFactory,
+  ValueInterpolator,
+} from "../utils/interpolation"
 import { collectJoints } from "./robotModelLogic"
 
 export type RobotAnimatorHandle = {
@@ -21,20 +25,39 @@ type RobotAnimatorProps = {
   rapidlyChangingMotionState: MotionGroupState
   dhParameters: DHParameter[]
   onRotationChanged?: (joints: Object3D[], jointValues: number[]) => void
+  /**
+   * Strategy used to interpolate joint values towards each incoming motion
+   * state. Defaults to spring smoothing via {@link ValueInterpolator}. Provide a
+   * custom {@link MotionInterpolatorFactory} to tune the spring, follow the
+   * streamed pose exactly (no smoothing), or plug in any other behaviour.
+   */
+  createInterpolator?: MotionInterpolatorFactory
   children: React.ReactNode
 }
 
+const defaultCreateInterpolator: MotionInterpolatorFactory = (initialValues) =>
+  new ValueInterpolator(initialValues)
+
 const RobotAnimator = forwardRef<RobotAnimatorHandle, RobotAnimatorProps>(
   function RobotAnimator(
-    { rapidlyChangingMotionState, dhParameters, onRotationChanged, children },
+    {
+      rapidlyChangingMotionState,
+      dhParameters,
+      onRotationChanged,
+      createInterpolator = defaultCreateInterpolator,
+      children,
+    },
     ref,
   ) {
     const groupRef = useRef<Group | null>(null)
     const jointObjects = useRef<Object3D[]>([])
-    const interpolatorRef = useRef<ValueInterpolator | null>(null)
+    const interpolatorRef = useRef<MotionInterpolator | null>(null)
     const { invalidate } = useThree()
     const motionStateRef = useRef(rapidlyChangingMotionState)
     motionStateRef.current = rapidlyChangingMotionState
+
+    // Read the factory once on mount (see MotionInterpolatorFactory docs).
+    const createInterpolatorRef = useRef(createInterpolator)
 
     // Initialize interpolator
     // biome-ignore lint/correctness/useExhaustiveDependencies: pre-biome code
@@ -44,14 +67,11 @@ const RobotAnimator = forwardRef<RobotAnimatorHandle, RobotAnimatorProps>(
           (item) => item !== undefined,
         )
 
-      interpolatorRef.current = new ValueInterpolator(initialJointValues, {
-        tension: 120, // Controls spring stiffness - higher values create faster, more responsive motion
-        friction: 20, // Controls damping - higher values reduce oscillation and create smoother settling
-        threshold: 0.001,
-      })
+      interpolatorRef.current =
+        createInterpolatorRef.current(initialJointValues)
 
       return () => {
-        interpolatorRef.current?.destroy()
+        interpolatorRef.current?.destroy?.()
       }
     }, [])
 

--- a/src/components/robots/SupportedLinearAxis.tsx
+++ b/src/components/robots/SupportedLinearAxis.tsx
@@ -4,6 +4,7 @@ import { Suspense, useCallback, useEffect, useState } from "react"
 import { ErrorBoundary } from "react-error-boundary"
 import type * as THREE from "three"
 import { externalizeComponent } from "../../externalizeComponent"
+import type { MotionInterpolatorFactory } from "../utils/interpolation"
 import ConsoleFilter from "../ConsoleFilter"
 import { DHLinearAxis } from "./DHLinearAxis"
 import { GenericRobot } from "./GenericRobot"
@@ -28,6 +29,13 @@ export type SupportedLinearAxisProps = {
   ) => Promise<string> | undefined
   postModelRender?: () => void
   transparentColor?: string
+  /**
+   * Strategy used to interpolate joint values towards each incoming motion
+   * state. Defaults to spring smoothing; provide a custom
+   * {@link MotionInterpolatorFactory} to tune the spring, follow the streamed
+   * pose exactly (no smoothing), or plug in any other behaviour.
+   */
+  createInterpolator?: MotionInterpolatorFactory
 } & ThreeElements["group"]
 
 export const SupportedLinearAxis = externalizeComponent(
@@ -40,6 +48,7 @@ export const SupportedLinearAxis = externalizeComponent(
     postModelRender,
     transparentColor,
     instanceUrl,
+    createInterpolator,
     ...props
   }: SupportedLinearAxisProps) => {
     const [robotGroup, setRobotGroup] = useState<THREE.Group | null>(null)
@@ -79,6 +88,7 @@ export const SupportedLinearAxis = externalizeComponent(
             <LinearAxisAnimator
               rapidlyChangingMotionState={rapidlyChangingMotionState}
               dhParameters={dhParameters}
+              createInterpolator={createInterpolator}
             >
               <GenericRobot
                 modelURL={(() => {

--- a/src/components/robots/SupportedRobot.tsx
+++ b/src/components/robots/SupportedRobot.tsx
@@ -15,6 +15,7 @@ import type * as THREE from "three"
 import { externalizeComponent } from "../../externalizeComponent"
 import ConsoleFilter from "../ConsoleFilter"
 import { GenericRobot } from "./GenericRobot"
+import type { MotionInterpolatorFactory } from "../utils/interpolation"
 import RobotAnimator, { type RobotAnimatorHandle } from "./RobotAnimator"
 import { applyGhostStyle, removeGhostStyle } from "./ghostStyle"
 import { defaultGetModel } from "./robotModelLogic"
@@ -36,6 +37,13 @@ export type SupportedRobotProps = {
   ) => Promise<string> | undefined
   postModelRender?: () => void
   transparentColor?: string
+  /**
+   * Strategy used to interpolate joint values towards each incoming motion
+   * state. Defaults to spring smoothing; provide a custom
+   * {@link MotionInterpolatorFactory} to tune the spring, follow the streamed
+   * pose exactly (no smoothing), or plug in any other behaviour.
+   */
+  createInterpolator?: MotionInterpolatorFactory
 } & ThreeElements["group"]
 
 export const SupportedRobot = externalizeComponent(
@@ -48,6 +56,7 @@ export const SupportedRobot = externalizeComponent(
     postModelRender,
     transparentColor,
     instanceUrl,
+    createInterpolator,
     ...props
   }: SupportedRobotProps) => {
     const [robotGroup, setRobotGroup] = useState<THREE.Group | null>(null)
@@ -108,6 +117,7 @@ export const SupportedRobot = externalizeComponent(
               ref={robotAnimatorRef}
               rapidlyChangingMotionState={rapidlyChangingMotionState}
               dhParameters={dhParameters}
+              createInterpolator={createInterpolator}
             >
               <GenericRobot
                 modelURL={modelURL}

--- a/src/components/utils/interpolation.ts
+++ b/src/components/utils/interpolation.ts
@@ -56,7 +56,42 @@ export interface InterpolationOptions {
   onComplete?: (values: number[]) => void
 }
 
-export class ValueInterpolator {
+/**
+ * Minimal contract a per-frame value interpolator must fulfil to drive robot
+ * joint animation. This is the seam the visualizer components animate against —
+ * {@link ValueInterpolator} is the default implementation, but consumers can
+ * supply their own strategy (no smoothing, a different spring, easing, a Kalman
+ * filter, …) via {@link MotionInterpolatorFactory}.
+ */
+export interface MotionInterpolator {
+  /** Set the new target values the interpolator should move towards. */
+  setTarget(values: number[]): void
+  /**
+   * Advance the interpolation by `delta` seconds and return `true` once the
+   * current values have settled at the target (so the caller can stop
+   * requesting frames until the next target arrives).
+   */
+  update(delta: number): boolean
+  /** Current interpolated values to apply to the scene this frame. */
+  getCurrentValues(): number[]
+  /** Optional cleanup hook invoked when the owning component unmounts. */
+  destroy?(): void
+}
+
+/**
+ * Produces a {@link MotionInterpolator} seeded with the robot's initial joint
+ * values. The visualizer calls this once per mount; return a fresh instance so
+ * each robot owns its own interpolation state.
+ *
+ * The factory is read once when the animator mounts, so pass a stable reference
+ * (module-level function or memoized) rather than an inline closure that changes
+ * every render.
+ */
+export type MotionInterpolatorFactory = (
+  initialValues: number[],
+) => MotionInterpolator
+
+export class ValueInterpolator implements MotionInterpolator {
   private currentValues: number[] = []
   private targetValues: number[] = []
   private previousTargetValues: number[] = []


### PR DESCRIPTION
## Problem

Robot preview smoothing used a spring interpolator with hardcoded physics (`tension=120`, `friction=20`) in `RobotAnimator`/`LinearAxisAnimator`. Consumers streaming already-exact poses (e.g. trajectory previews) got spring lag — the robot fell behind and overshot waypoints — with no way to tune or disable it.

## Change

Make the interpolation strategy pluggable instead of hardcoded:

- New `MotionInterpolator` contract + `MotionInterpolatorFactory` type.
- New optional prop `createInterpolator?` on `SupportedRobot`, `SupportedLinearAxis`, `MotionGroupVisualizer`.
- `ValueInterpolator` now `implements MotionInterpolator` and stays the default.

Consumers can inject any strategy (tuned spring, instant/no-smoothing, or custom):

```tsx
<SupportedRobot createInterpolator={(v) => new ValueInterpolator(v, { tension: 500 })} {...props} />
```

## Backward compatibility

Fully compatible — the default factory reproduces the previous spring behaviour exactly. API reports are purely additive.

## Verification

`tsc`, `biome`, 98/98 unit tests, and `vite build` all pass; `api-extractor` reports regenerated.
